### PR TITLE
Add a before_symlink Proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ before_migrate      | A proc containing resources to be executed before the migr
 after_migrate       | A proc containing resources to be executed after the migration Proc                  | Proc    |
 migrate             | A proc containing resources to be executed during the migration stage                | Proc    |
 restart_proc        | A proc containing resources to be executed at the end of a successful deploy         | Proc    |
+before_symlink      | A proc containing resources to be executed before the symlinks are created           | Proc    |
 force               | Forcefully deploy an artifact even if the artifact has already been deployed         | Boolean | false
 should_migrate      | Notify the provider if it should perform application migrations                      | Boolean | false
 keep                | Specify a number of artifacts deployments to keep on disk                            | Integer | 2

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -67,7 +67,11 @@ action :deploy do
       user new_resource.owner
       group new_resource.group
     end
+  end
 
+  recipe_eval(&new_resource.before_symlink)
+
+  recipe_eval do
     symlink_it_up!
   end
 

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -35,6 +35,7 @@ attribute :before_migrate, :kind_of     => Proc
 attribute :after_migrate, :kind_of      => Proc
 attribute :migrate, :kind_of            => Proc
 attribute :restart_proc, :kind_of       => Proc
+attribute :before_symlink, :kind_of     => Proc
 attribute :force, :kind_of              => [ TrueClass, FalseClass ], :default => false
 attribute :should_migrate, :kind_of     => [ TrueClass, FalseClass ], :default => false
 attribute :keep, :kind_of               => Integer, :default => 2


### PR DESCRIPTION
Some of the symlinks (like tmp/pids) may be in subdirs that don't
exist, so this is where you could make sure they get created.
