### PR TITLE
Support a "*" wildcard env for nexus config lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Your data bag should look like the following:
       }
     }
 
-After your encrypted data bag is setup you can use Maven identifiers for your artifact_location.
+After your encrypted data bag is setup you can use Maven identifiers
+for your artifact_location. If many environments share the same configuration,
+you can use "*" as a wildcard environment name.
 
 ### Examples
 

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -11,7 +11,7 @@ class Chef
           raise EncryptedDataBagNotFound.new(data_bag_key)
         end
 
-        config = data_bag_item[node.chef_environment]
+        config = data_bag_item[node.chef_environment] || data_bag_item["*"]
         unless config
           raise EnvironmentNotFound.new(data_bag_key, node.chef_environment)
         end


### PR DESCRIPTION
If you have many environments sharing a single set of Nexus
credentials, configuring the databag with many copies is excessive
duplication. This patch avoids it.
