### PR TITLE
retrieve_from_http redownloads the artifact every time

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -250,6 +250,7 @@ private
       source new_resource.artifact_location
       owner new_resource.owner
       group new_resource.group
+      checksum new_resource.artifact_checksum
       backup false
 
       action :create

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -25,6 +25,7 @@ actions :deploy
 attribute :artifact_name, :kind_of      => String, :required => true, :name_attribute => true
 attribute :artifact_location, :kind_of  => String
 attribute :artifact_url, :kind_of       => String, :regex => URI.regexp(['http', 'https'])
+attribute :artifact_checksum, :kind_of  => String
 attribute :deploy_to, :kind_of          => String, :required => true
 attribute :version, :kind_of            => String
 attribute :owner, :kind_of              => String, :required => true, :regex => Chef::Config[:user_valid_regex]


### PR DESCRIPTION
An artifact will be redownloaded every time it makes it past the `deployed?` check and into the `retrieve_from_http` method.

Since `retrieve_from_http` uses the `remote_file` resource, add an attribute to the LWRP to pass through a checksum so the artifact won't be redownloaded if it is already there.

Fixes #17
