### PR TITLE
Make artifact-cookbook more idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ group               | Group of files created and modified                       
 environment         | An environment hash used by resources within the provider                            | Hash    | Hash.new
 symlinks            | A hash that maps files in the shared directory to their paths in the current release | Hash    | Hash.new
 shared_directories  | Directories to be created in the shared folder                                       | Array   | %w{ log pids }
+before_extract      | A proc containing resources to be executed before the artifact package is extracted  | Proc    |
 before_migrate      | A proc containing resources to be executed before the migration Proc                 | Proc    |
 after_migrate       | A proc containing resources to be executed after the migration Proc                  | Proc    |
 migrate             | A proc containing resources to be executed during the migration stage                | Proc    |

--- a/libraries/chef_artifact_errors.rb
+++ b/libraries/chef_artifact_errors.rb
@@ -27,11 +27,5 @@ class Chef
         "[artifact] Unable to locate the Artifact data bag item '#{data_bag_key}' for your environment '#{environment}'."
       end
     end
-
-    class ManifestFileNotFound < ArtifactError
-      def message
-        "No manifest file found for current version, deploying anyway."
-      end
-    end
   end
 end

--- a/libraries/chef_artifact_errors.rb
+++ b/libraries/chef_artifact_errors.rb
@@ -27,5 +27,11 @@ class Chef
         "[artifact] Unable to locate the Artifact data bag item '#{data_bag_key}' for your environment '#{environment}'."
       end
     end
+
+    class ManifestFileNotFound < ArtifactError
+      def message
+        "No manifest file found for current version, deploying anyway."
+      end
+    end
   end
 end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -162,7 +162,7 @@ private
 
   def deployed?
     require 'yaml'
-    if previous_release_path.nil? || ::File.exists?(::File.join(previous_release_path, "manifest.yaml"))
+    if previous_release_path.nil? || !::File.exists?(::File.join(previous_release_path, "manifest.yaml"))
       Chef::Log.warn "No manifest file found for current version, deploying anyway."
       return false
     end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -269,9 +269,12 @@ private
     ruby_block "retrieve from nexus" do
       block do
         require 'nexus_cli'
-        config = Chef::Artifact.nexus_config_for(node)
-        remote = NexusCli::Factory.create(config)
-        remote.pull_artifact(new_resource.artifact_location, version_container_path)
+
+        unless Chef::ChecksumCache.checksum_for_file(cached_tar_path) == new_resource.artifact_checksum
+          config = Chef::Artifact.nexus_config_for(node)
+          remote = NexusCli::Factory.create(config)
+          remote.pull_artifact(new_resource.artifact_location, version_container_path)
+        end
       end
     end
   end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -162,14 +162,12 @@ private
 
   def deployed?
     require 'yaml'
-    begin
-      raise Chef::Artifact::ManifestFileNotFound if previous_release_path.nil? || ::File.exists?(::File.join(previous_release_path, "manifest.yaml"))
-      Chef::Log.info "Loading manifest.yaml file from directory: #{previous_release_path}"
-      original_manifest = YAML.load_file(::File.join(previous_release_path, "manifest.yaml"))
-    rescue Chef::Artifact::ManifestFileNotFound => e
-      Chef::Log.warn e.message
+    if previous_release_path.nil? || ::File.exists?(::File.join(previous_release_path, "manifest.yaml"))
+      Chef::Log.warn "No manifest file found for current version, deploying anyway."
       return false
     end
+    Chef::Log.info "Loading manifest.yaml file from directory: #{previous_release_path}"
+    original_manifest = YAML.load_file(::File.join(previous_release_path, "manifest.yaml"))    
     
     current_manifest = create_manifest(current_path)
     differences = original_manifest.find do |key, value|

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -63,6 +63,8 @@ action :deploy do
 
     retrieve_artifact!
 
+    recipe_eval(&new_resource.before_extract) if new_resource.before_extract
+
     if new_resource.is_tarball
       extract_artifact
     else

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -161,10 +161,11 @@ private
   def deployed?
     require 'yaml'
     begin
+      raise Chef::Artifact::ManifestFileNotFound if previous_release_path.nil? || ::File.exists?(::File.join(previous_release_path, "manifest.yaml"))
       Chef::Log.info "Loading manifest.yaml file from directory: #{previous_release_path}"
       original_manifest = YAML.load_file(::File.join(previous_release_path, "manifest.yaml"))
-    rescue Errno::ENOENT, TypeError
-      Chef::Log.info "No manifest file found for current version, deploying anyway"
+    rescue Chef::Artifact::ManifestFileNotFound => e
+      Chef::Log.warn e.message
       return false
     end
     

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -33,6 +33,7 @@ attribute :group, :kind_of              => String, :required => true, :regex => 
 attribute :environment, :kind_of        => Hash, :default => Hash.new
 attribute :symlinks, :kind_of           => Hash, :default => Hash.new
 attribute :shared_directories, :kind_of => Array, :default => %w{ system pids log }
+attribute :before_extract, :kind_of     => Proc
 attribute :before_migrate, :kind_of     => Proc
 attribute :after_migrate, :kind_of      => Proc
 attribute :migrate, :kind_of            => Proc


### PR DESCRIPTION
- Use a checksum when we talk to Nexus as well.
- Do a better check to see if someone has mucked around with an already deployed artifact.
