### PR TITLE
Bug Fixes for 1.0.0

### DIFF
--- a/fixtures/artifact_test/metadata.rb
+++ b/fixtures/artifact_test/metadata.rb
@@ -1,4 +1,4 @@
-maintainer       "YOUR_COMPANY_NAME"
+maintainer       "Riot Games"
 maintainer_email "YOUR_EMAIL"
 license          "All rights reserved"
 description      "Installs/Configures artifact_test"

--- a/fixtures/artifact_test/recipes/symlink_tests.rb
+++ b/fixtures/artifact_test/recipes/symlink_tests.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: artifact_test
+# Recipe:: symlink_tests
+#
+# Copyright 2012, Riot Games
+#
+# All rights reserved - Do Not Redistribute
+#
+
+group "artifact"
+user "artifact" do
+  group "artifact"
+end
+
+artifact_deploy "artifact_test" do
+  version node[:artifact_test][:version]
+  artifact_location node[:artifact_test][:location]
+  artifact_checksum node[:artifact_test][:checksum]
+  deploy_to "/srv/artifact_test"
+  owner "artifact"
+  group "artifact"
+  force true
+  symlinks({"directory_that_should_never_exist" => "directory_that_should_never_exist"})
+
+  action :deploy
+end
+
+ruby_block "make sure directory_that_should_never_exist exists" do
+  block do
+    current_version = Chef::Artifact.get_current_deployed_version('/srv/artifact_test')
+    shared_directory_exists = ::File.directory?("/srv/artifact_test/shared/directory_that_should_never_exist")
+    symlink_exists = ::File.symlink?("/srv/artifact_test/releases/#{current_version}/directory_that_should_never_exist")
+    Chef::Application.fatal! "directory /srv/artifact_test/shared/directory_that_should_never_exist does not exist!" unless shared_directory_exists
+    Chef::Application.fatal! "a symlink at /srv/artifact_test/#{current_version}/directory_that_should_never_exist does not exist!" unless symlink_exists
+  end
+end

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -35,18 +35,20 @@ class Chef
       # 
       # @param  node [Chef::Node] the node
       # @param  artifact_location [String] a colon-separated Maven identifier string that represents the artifact
+      # @param  ssl_verify [Boolean] a boolean to pass through the the NexusCli::RemoteFactory#create method. This
+      #   is a TERRIBLE IDEA and you should never want to set this to false!
       # 
       # @example
       #   Chef::Artifact.get_actual_version(node, "com.myartifact:my-artifact:latest:tgz") => "2.0.5"
       #   Chef::Artifact.get_actual_version(node, "com.myartifact:my-artifact:1.0.1:tgz")  => "1.0.1"
       # 
       # @return [String] the version number that latest resolves to or the passed in value
-      def get_actual_version(node, artifact_location)
+      def get_actual_version(node, artifact_location, ssl_verify=true)
         version = artifact_location.split(':')[2]
         if version.casecmp("latest") == 0
           require 'nexus_cli'
           config = nexus_config_for(node)
-          remote = NexusCli::RemoteFactory.create(config)
+          remote = NexusCli::RemoteFactory.create(config, ssl_verify)
           Nokogiri::XML(remote.get_artifact_info(artifact_location)).xpath("//version").first.content()
         else
           version

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -34,22 +34,19 @@ class Chef
       # actual version number is when 'latest' is given.
       # 
       # @param  node [Chef::Node] the node
-      # @param  group_id [String] the group_id of the artifact
-      # @param  artifact_id [String] the artifact_id of the artifact
-      # @param  version [String] the version of the artifact
-      # @param  extension [String] the extension of the artifact
+      # @param  artifact_location [String] a colon-separated Maven identifier string that represents the artifact
       # 
       # @example
-      #   Chef::Artifact.get_actual_version(node, "com.myartifact", "my-artifact", "latest", "tgz") => "2.0.5"
-      #   Chef::Artifact.get_actual_version(node, "com.myartifact", "my-artifact", "1.0.1", "tgz")  => "1.0.1"
+      #   Chef::Artifact.get_actual_version(node, "com.myartifact:my-artifact:latest:tgz") => "2.0.5"
+      #   Chef::Artifact.get_actual_version(node, "com.myartifact:my-artifact:1.0.1:tgz")  => "1.0.1"
       # 
       # @return [String] the version number that latest resolves to or the passed in value
-      def get_actual_version(node, group_id, artifact_id, version, extension)
+      def get_actual_version(node, artifact_location)
+        version = artifact_location.split(':')[2]
         if version.casecmp("latest") == 0
           require 'nexus_cli'
           config = nexus_config_for(node)
           remote = NexusCli::RemoteFactory.create(config)
-          artifact_location = [group_id, artifact_id, version, extension].join(':')
           Nokogiri::XML(remote.get_artifact_info(artifact_location)).xpath("//version").first.content()
         else
           version

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -56,7 +56,7 @@ def load_current_resource
     end
 
     group_id, artifact_id, extension = @new_resource.artifact_location.split(':')
-    @artifact_version  = Chef::Artifact.get_actual_version(node, [group_id, artifact_id, @new_resource.version, extension].join(':'))
+    @artifact_version  = Chef::Artifact.get_actual_version(node, [group_id, artifact_id, @new_resource.version, extension].join(':'), @new_resource.ssl_verify)
     @artifact_location = [group_id, artifact_id, artifact_version, extension].join(':')
   else
     @artifact_version = @new_resource.version
@@ -521,7 +521,7 @@ private
         require 'nexus_cli'
         unless ::File.exists?(cached_tar_path) && Chef::ChecksumCache.checksum_for_file(cached_tar_path) == new_resource.artifact_checksum
           config = Chef::Artifact.nexus_config_for(node)
-          remote = NexusCli::RemoteFactory.create(config, false)
+          remote = NexusCli::RemoteFactory.create(config, new_resource.ssl_verify)
           remote.pull_artifact(artifact_location, version_container_path)
         end
       end

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -50,6 +50,12 @@ attribute :after_migrate, :kind_of      => Proc
 attribute :migrate, :kind_of            => Proc
 attribute :restart, :kind_of            => Proc
 attribute :after_deploy, :kind_of       => Proc
+attribute :ssl_verify, :kind_of         => [ TrueClass, FalseClass ], :default => true
+
+def initialize(*args)
+  super
+  @action = :deploy
+end
 
 def artifact_deploy_path
   "#{Chef::Config[:file_cache_path]}/artifact_deploys"

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -51,11 +51,6 @@ attribute :migrate, :kind_of            => Proc
 attribute :restart, :kind_of            => Proc
 attribute :after_deploy, :kind_of       => Proc
 
-def initialize(*args)
-  super
-  @action = :deploy
-end
-
 def artifact_deploy_path
   "#{Chef::Config[:file_cache_path]}/artifact_deploys"
 end


### PR DESCRIPTION
Found a few bugs:
- `symlink_it_up!` was not executing in a recipe_eval block, meaning its actions would possible occur at the wrong time.
- inadequate logging in many methods
- add some testing around the symlink area of the provider.

Improvements
- simplify the API for `Chef::Artifact.get_actual_version` back to be more like it used to.

Changing the API for the library probably makes this a 1.1.0 release, but I feel like its worth it after having a conversation about its usage.

Adding #44 to this as well.
