### PR TITLE
Add option to artifact_deploy to remove a top level directory that makes configuration cumbersome

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -184,11 +184,11 @@ def extract_artifact!
         ::FileUtils.mv(release_pathname.children.first.children, release_path)
         ::FileUtils.rm_rf(top_level_dir)
       end
-      only_if { 
+      only_if do
         new_resource.remove_top_level_directory &&
           release_pathname.children.size == 1 &&
           release_pathname.children.first.directory?
-      }
+      end
     end
   end
 end

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -51,9 +51,7 @@ attribute :migrate, :kind_of            => Proc
 attribute :restart, :kind_of            => Proc
 attribute :after_deploy, :kind_of       => Proc
 attribute :ssl_verify, :kind_of         => [ TrueClass, FalseClass ], :default => true
-
-attribute :remove_top_level_directory, :kind_of => [ TrueClass, FalseClass ], :default => true
-
+attribute :remove_top_level_directory, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 def initialize(*args)
   super

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -52,6 +52,9 @@ attribute :restart, :kind_of            => Proc
 attribute :after_deploy, :kind_of       => Proc
 attribute :ssl_verify, :kind_of         => [ TrueClass, FalseClass ], :default => true
 
+attribute :remove_top_level_directory, :kind_of => [ TrueClass, FalseClass ], :default => true
+
+
 def initialize(*args)
   super
   @action = :deploy


### PR DESCRIPTION
current/top_level_directory/actual_install_files is annoying because you have to manually handle top_level_directory manually all over the place
