### PR TITLE
Manifest Checking can take too long

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source "http://rubygems.org"
 gem 'berkshelf', '>= 1.0.0'
 gem "chef", "~> 10.18"
 gem 'thor-foodcritic', '~> 0.1.2'
-gem 'vagrant', '~> 1.0.5'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 
 gem 'berkshelf', '>= 1.0.0'
 gem 'thor-foodcritic', '~> 0.1.2'
-
+gem 'vagrant', '~> 1.0.5'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "http://rubygems.org"
 
 gem 'berkshelf', '>= 1.0.0'
+gem "chef", "~> 10.18"
 gem 'thor-foodcritic', '~> 0.1.2'
 gem 'vagrant', '~> 1.0.5'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Provides your cookbooks with the Artifact Deploy LWRP
 # Requirements
 
 * Chef 10
+* Vagrant
 
 # Platforms
 
@@ -14,6 +15,10 @@ Provides your cookbooks with the Artifact Deploy LWRP
   * Windows Vista
   * Windows 2008 R2
   * Windows 7
+
+# Vagrant
+
+With Vagrant 1.1, there is no longer a Vagrant RubyGem to install. Instead, follow the instructions on the [VagrantUp](http://docs.vagrantup.com/v2/installation/index.html) documentation pages.
 
 # Resources / Providers
 

--- a/fixtures/artifact_test/recipes/skip_manifest_check.rb
+++ b/fixtures/artifact_test/recipes/skip_manifest_check.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: artifact_test
-# Recipe:: default
+# Recipe:: skip_manifest_check
 #
 # Copyright 2012, Riot Games
 #
@@ -17,6 +17,13 @@ artifact_deploy "artifact_test" do
   deploy_to node[:artifact_test][:deploy_to]
   owner "artifacts"
   group "artifact"
-
+  skip_manifest_check true
   action :deploy
+end
+
+ruby_block "make sure manifest.yaml does not exist" do
+  block do
+    manifest_file = ::File.join(node[:artifact_test][:deploy_to], "current", "manifest.yaml")
+    Chef::Application.fatal! "Manifest file exists!" if ::File.exists?(manifest_file)
+  end
 end

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -52,6 +52,7 @@ attribute :restart, :kind_of            => Proc
 attribute :after_deploy, :kind_of       => Proc
 attribute :ssl_verify, :kind_of         => [ TrueClass, FalseClass ], :default => true
 attribute :remove_top_level_directory, :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :skip_manifest_check, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 def initialize(*args)
   super


### PR DESCRIPTION
If you have a large artifact, or many files in your artifact, the manifest checking can become a decently expensive operation.

We should probably have an attribute that allows this checking to be skipped when we really trust ourselves to not change the internals of an artifact.
