### PR TITLE
Checkums are not used properly and force can have strange effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fixtures/databags/
 .kitchen/
 .kitchen.local.yml
 .vagrant
+.DS_Store

--- a/fixtures/artifact_test/recipes/force_install.rb
+++ b/fixtures/artifact_test/recipes/force_install.rb
@@ -5,6 +5,7 @@ artifact_deploy "artifact_test" do
   deploy_to node[:artifact_test][:deploy_to]
   owner "artifacts"
   group "artifact"
-
+  force true
+  remove_on_force true
   action :deploy
 end

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -126,8 +126,20 @@ class Chef
         remote.pull_artifact(source, destination_dir)
       end
 
-      # TODO: This method should probably move into the Nexus-CLI
+      
+      # Generates a URL that hits the Nexus redirect endpoint which will
+      # result in an artifact being downloaded.
+      #
+      # @example
+      #   Chef::Artifact.artifact_download_url_for(node, "com.myartifact:my-artifact:1.0.1:tgz")
+      #     => "http://my-nexus:8081/nexus/service/local/artifact/maven/redirect?g=com.myartifact&a=my-artifact&v=1.0.1&e=tgz&r=my_repo"
+      #
+      # @param  node [Chef::Node]
+      # @param  source [String] colon separated Nexus location
+      # 
+      # @return [String] a URL that can be used to retrieve an artifact
       def artifact_download_url_for(node, source)
+        # TODO: Move this method into the nexus-cli
         config = nexus_config_for(node)
         group_id, artifact_id, version, extension = source.split(':')
         query_string = "g=#{group_id}&a=#{artifact_id}&v=#{version}&e=#{extension}&r=#{config['repository']}"

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -126,6 +126,16 @@ class Chef
         remote.pull_artifact(source, destination_dir)
       end
 
+      # TODO: This method should probably move into the Nexus-CLI
+      def artifact_download_url_for(node, source)
+        config = nexus_config_for(node)
+        group_id, artifact_id, version, extension = source.split(':')
+        query_string = "g=#{group_id}&a=#{artifact_id}&v=#{version}&e=#{extension}&r=#{config['repository']}"
+        uri_for_url = URI(config['url'])
+        builder = uri_for_url.scheme =~ /https/ ? URI::HTTPS : URI::HTTP
+        builder.build(host: uri_for_url.host, port: uri_for_url.port, path: '/nexus/service/local/artifact/maven/redirect', query: query_string).to_s
+      end
+
       # Returns the currently deployed version of an artifact given that artifacts
       # installation directory by reading what directory the 'current' symlink
       # points to.

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -249,7 +249,10 @@ end
 # as the one to be installed, we are forcing, and remove_on_force is
 # set. Only bad people will use this.
 def delete_current_if_forcing!
-  return unless @new_resource.force && remove_on_force? && (get_current_release_version == artifact_version || previous_version_numbers.include?(artifact_version))
+  return unless @new_resource.force 
+  return unless remove_on_force? 
+  return unless get_current_release_version == artifact_version || previous_version_numbers.include?(artifact_version)
+
   recipe_eval do
     log "artifact_deploy[delete_current_if_forcing!] #{artifact_version} deleted because remove_on_force is true" do
       level :info

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -570,6 +570,7 @@ private
       command Chef::Artifact.copy_command_for(new_resource.artifact_location, cached_tar_path)
       user    new_resource.owner
       group   new_resource.group
+      only_if { !::File.exists?(cached_tar_path) || !FileUtils.compare_file(new_resource.artifact_location, cached_tar_path) }
     end
   end
 

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -53,6 +53,7 @@ attribute :after_deploy, :kind_of       => Proc
 attribute :ssl_verify, :kind_of         => [ TrueClass, FalseClass ], :default => true
 attribute :remove_top_level_directory, :kind_of => [ TrueClass, FalseClass ], :default => false
 attribute :skip_manifest_check, :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :remove_on_force, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 def initialize(*args)
   super

--- a/test/integration/forcing/minitest/forcing_spec.rb
+++ b/test/integration/forcing/minitest/forcing_spec.rb
@@ -4,11 +4,11 @@ describe "forcing" do
   
   describe "when an artifact with the same version but different files is installed" do
     it "has the new files" do
-      assert File.exists?("/srv/artifact_test/current/lib/foo.rb")
+      assert File.exists?("/srv/artifact_test/current/artifact_test_app/lib/foo.rb")
     end
 
     it "no longer has the deleted files" do
-      refute File.exists?("/srv/artifact_test/current/lib/bar.rb")
+      refute File.exists?("/srv/artifact_test/current/artifact_test_app/lib/bar.rb")
     end
   end
 end


### PR DESCRIPTION
The logic in `retrieve_artifact!` leaves something to be desired. 
- You can end up with nothign happening when you use the `force` attribute to redeploy the same artifact because of the initial `if` condition.
- `Chef::ChecksumCache` might need to be used better depending on the path we go down. At the moment, the simplest case should be handled with the remote_file resource. Others might have bugs.

Should refactor the logic in this method so that it is more clear. Possibly clear up the logging as well. This may also include some sort of implementation for #28.

Edit: It appears that the class is also now `Chef::Digester` in Chef > 11.0
