### PR TITLE
Amazon S3 as an artifact deployment source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'test-kitchen', git: 'git@github.com:opscode/test-kitchen.git'
 gem 'kitchen-vagrant', :group => :integration
 gem 'rspec'
 gem 'chef', '~> 10.18'
+gem 'aws-sdk', '= 1.11.0'

--- a/README.md
+++ b/README.md
@@ -233,8 +233,6 @@ If you wish to keep them in the root of your bucket, just omit the ```deploys/``
 
 If you wish to provide your AWS credentials in a data_bag, the format is:
 
-Your data bag should look like the following:
-
     {
       "id": "_wildcard",
       "aws": {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pre_seed | Pre-seed the artifact package |
 Attribute                  | Description                                                                          |Type     | Default
 ---------                  |-------------                                                                         |-----    |--------
 artifact_name              | Name of the artifact package to deploy                                               | String  | name
-artifact_location          | URL, local path, or Maven identifier of the artifact package to download             | String  |
+artifact_location          | URL, S3 path, local path, or Maven identifier of the artifact package to download    | String  |
 artifact_checksum          | The SHA256 checksum of the artifact package that is being downloaded                 | String  |
 deploy_to                  | Deploy directory where releases are stored and linked                                | String  |
 version                    | Version of the artifact being deployed                                               | String  |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ create   | Download the artifact file    | Yes
 Attribute              | Description                                                                          |Type     | Default
 ---------              |-------------                                                                         |-----    |--------
 path                   | The path to download the artifact to                                                 | String  | name
-location               | The location to the artifact file. Either a nexus identifier, S3 path or URL        | String  |
+location               | The location to the artifact file. Either a nexus identifier, S3 path or URL         | String  |
 checksum               | The SHA256 checksum for verifying URL downloads. Not used when location is Nexus     | String  |
 owner                  | Owner of the downloaded file                                                         | String  |
 group                  | Group of the downloaded file                                                         | String  |

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -97,7 +97,7 @@ class Chef
       # @return [String] the version number that latest resolves to or the passed in value
       def get_actual_version(node, artifact_location, ssl_verify=true)
         version = artifact_location.split(':')[2]
-        if version.casecmp("latest") == 0
+        if latest?(version)
           require 'nexus_cli'
           require 'rexml/document'
           config = data_bag_config_for(node, DATA_BAG_NEXUS)
@@ -228,7 +228,7 @@ class Chef
       #
       # @return [Boolean] true when the location matches s3
       def from_s3?(location)
-        location =~ URI::regexp('s3')
+        location_of_type(location, 's3')
       end
 
       # Returns true when the artifact is believed to be from an
@@ -238,7 +238,26 @@ class Chef
       # 
       # @return [Boolean] true when the location matches http or https.
       def from_http?(location)
-        location =~ URI::regexp(['http', 'https'])
+        location_of_type(location, %w(http https))
+      end
+
+      # Returns true when the location URI scheme matches the type
+      #
+      # @param  location [String] the location URI to check
+      # @param  uri_type [Array] list of URI types to check
+      #
+      # @return [Boolean] true when the location matches the given URI type
+      def location_of_type(location, uri_type)
+        not (location =~ URI::regexp(uri_type)).nil?
+      end
+
+      # Convenience method for determining whether a String is "latest"
+      #
+      # @param  version [String] the version of the configured artifact to check
+      #
+      # @return [Boolean] true when version matches (case-insensitive) "latest"
+      def latest?(version)
+        version.casecmp("latest") == 0
       end
 
       # Returns the currently deployed version of an artifact given that artifacts

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -155,11 +155,12 @@ class Chef
                 :secret_access_key => config['secret_access_key'])
           end
 
-          raise S3BucketNotFoundError.new(bucket_name) unless s3.buckets.has_key?(bucket_name)
           bucket = s3.buckets[bucket_name]
+          raise S3BucketNotFoundError.new(bucket_name) unless bucket.exists?
 
-          raise S3ArtifactNotFoundError.new(bucket_name, object_name) unless bucket.objects.has_key?(object_name)
           object = bucket.objects[object_name]
+          raise S3ArtifactNotFoundError.new(bucket_name, object_name) unless object.exists?
+
           Chef::Log.debug("Downloading #{object_name} from S3 bucket #{bucket_name}")
           ::File.open(destination_file, 'w') do |file|
             object.read do |chunk|

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -64,7 +64,7 @@ class Chef
       # @param  source [String] the deployment source to load configuration for
       # 
       # @return [Chef::DataBagItem] the data bag item
-      def config_for(node, source)
+      def data_bag_config_for(node, source)
         data_bag_item = if Chef::Config[:solo]
           Chef::DataBagItem.load(DATA_BAG, WILDCARD_DATABAG_ITEM) rescue {}
         else
@@ -78,7 +78,7 @@ class Chef
         return data_bag_item if DATA_BAG_NEXUS == source
 
         # no config found for source
-        return {}
+        {}
       end
 
       # Uses the provided parameters to make a call to the data bag
@@ -100,7 +100,7 @@ class Chef
         if version.casecmp("latest") == 0
           require 'nexus_cli'
           require 'rexml/document'
-          config = config_for(node, DATA_BAG_NEXUS)
+          config = data_bag_config_for(node, DATA_BAG_NEXUS)
           if config.empty?
             raise DataBagNotFound.new(DATA_BAG_NEXUS)
           end
@@ -125,7 +125,7 @@ class Chef
       # information about that file. See NexusCli::ArtifactActions#pull_artifact.
       def retrieve_from_nexus(node, source, destination_dir, options = {})
         require 'nexus_cli'
-        config = config_for(node, DATA_BAG_NEXUS)
+        config = data_bag_config_for(node, DATA_BAG_NEXUS)
         if config.empty?
           raise DataBagNotFound.new(DATA_BAG_NEXUS)
         end
@@ -142,7 +142,7 @@ class Chef
       def retrieve_from_s3(node, source_file, destination_file)
         begin
           require 'aws-sdk'
-          config = config_for(node, DATA_BAG_AWS)
+          config = data_bag_config_for(node, DATA_BAG_AWS)
           protocol, bucket_name, object_name = URI.split(source_file).compact
           object_name = object_name[1..-1]
           if config.empty?

--- a/libraries/chef_artifact_errors.rb
+++ b/libraries/chef_artifact_errors.rb
@@ -2,7 +2,7 @@ class Chef
   module Artifact
     class ArtifactError < StandardError; end
 
-    class EncryptedDataBagNotFound < ArtifactError
+    class DataBagNotFound < ArtifactError
       attr_reader :data_bag_key
 
       def initialize(data_bag_key)
@@ -10,7 +10,7 @@ class Chef
       end
 
       def message
-        "[artifact] Unable to locate the Artifact encrypted data bag '#{DATA_BAG}' or data bag item '#{data_bag_key}' for your environment."
+        "[artifact] Unable to locate the Artifact data bag '#{DATA_BAG}' or data bag item '#{data_bag_key}' for your environment."
       end
     end
 
@@ -37,6 +37,32 @@ class Chef
     class ArtifactChecksumError < ArtifactError
       def message
         "[artifact] Downloaded file checksum does not match the provided checksum. Your download may be corrupted or your checksum may not be correct."
+      end
+    end
+
+    class S3BucketNotFoundError < ArtifactError
+      attr_reader :bucket_name
+
+      def initialize(bucket_name)
+        @bucket_name = bucket_name
+      end
+
+      def message
+        "[artifact] Unable to locate the S3 bucket: #{bucket_name}"
+      end
+    end
+
+    class S3ArtifactNotFoundError < ArtifactError
+      attr_reader :bucket_name
+      attr_reader :object_path
+
+      def initialize(bucket_name, object_path)
+        @bucket_name = bucket_name
+        @object_path = object_path
+      end
+
+      def message
+        "[artifact] Unable to locate the artifact on S3 at the path #{bucket_name}/#{object_path}"
       end
     end
   end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -58,10 +58,12 @@ def load_current_resource
     @artifact_version  = Chef::Artifact.get_actual_version(node, [group_id, artifact_id, @new_resource.version, extension].join(':'), @new_resource.ssl_verify)
     @artifact_location = [group_id, artifact_id, artifact_version, extension].join(':')
   elsif from_s3?(@new_resource.artifact_location)
-    %W{libxml2 libxslt libxml2-devel libxslt-devel}.each do |nokogiri_requirement|
-      package nokogiri_requirement do
-        action :install
-      end.run_action(:install)
+    unless Chef::Artifact.windows?
+      %W{libxml2 libxslt libxml2-devel libxslt-devel}.each do |nokogiri_requirement|
+        package nokogiri_requirement do
+          action :install
+        end.run_action(:install)
+      end
     end
 
     chef_gem "aws-sdk" do

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -21,7 +21,6 @@
 #
 require 'digest'
 require 'pathname'
-require 'uri'
 require 'yaml'
 
 attr_reader :release_path
@@ -36,7 +35,7 @@ attr_reader :artifact_location
 attr_reader :artifact_version
 
 def load_current_resource
-  if latest?(@new_resource.version) && from_http?(@new_resource.artifact_location)
+  if Chef::Artifact.latest?(@new_resource.version) && Chef::Artifact.from_http?(@new_resource.artifact_location)
     Chef::Application.fatal! "You cannot specify the latest version for an artifact when attempting to download an artifact using http(s)!"
   end
 
@@ -49,7 +48,7 @@ def load_current_resource
     version "3.2.11"
   end
 
-  if from_nexus?(@new_resource.artifact_location)
+  if Chef::Artifact.from_nexus?(@new_resource.artifact_location)
     chef_gem "nexus_cli" do
       version "3.0.0"
     end
@@ -240,7 +239,7 @@ end
 
 # Returns the filename of the artifact being installed when the LWRP
 # is called. Depending on how the resource is called in a recipe, the
-# value returned by this method will change. If from_nexus?, return the
+# value returned by this method will change. If Chef::Artifact.from_nexus?, return the
 # concatination of "artifact_id-version.extension" otherwise return the
 # basename of where the artifact is located.
 # 
@@ -252,7 +251,7 @@ end
 # 
 # @return [String] the artifacts filename
 def artifact_filename
-  if from_nexus?(new_resource.artifact_location)    
+  if Chef::Artifact.from_nexus?(new_resource.artifact_location)
     group_id, artifact_id, version, extension = artifact_location.split(":")
     unless extension
       extension = "jar"
@@ -532,13 +531,13 @@ private
   # @return [void]
   def retrieve_artifact!
     recipe_eval do
-      if from_http?(new_resource.artifact_location)
+      if Chef::Artifact.from_http?(new_resource.artifact_location)
         Chef::Log.info "artifact_deploy[retrieve_artifact!] Retrieving artifact from #{artifact_location}"
         retrieve_from_http
-      elsif from_nexus?(new_resource.artifact_location)
+      elsif Chef::Artifact.from_nexus?(new_resource.artifact_location)
         Chef::Log.info "artifact_deploy[retrieve_artifact!] Retrieving artifact from Nexus using #{artifact_location}"
         retrieve_from_nexus
-      elsif from_s3?(new_resource.artifact_location)
+      elsif Chef::Artifact.from_s3?(new_resource.artifact_location)
         Chef::Log.info "artifact_deploy[retrieve_artifact!] Retrieving artifact from S3 using #{artifact_location}"
         retrieve_from_s3
       elsif ::File.exist?(new_resource.artifact_location)
@@ -548,45 +547,6 @@ private
         Chef::Application.fatal! "artifact_deploy[retrieve_artifact!] Cannot retrieve artifact #{artifact_location}! Please make sure the artifact exists in the specified location."
       end
     end
-  end
-
-  # Returns true when the artifact is believed to be from an
-  # http source.
-  # 
-  # @param  location [String] the artifact_location
-  # 
-  # @return [Boolean] true when the location matches http or https.
-  def from_http?(location)
-    location =~ URI::regexp(['http', 'https'])
-  end
-
-  # Returns true when the artifact is believed to be from a
-  # Nexus source.
-  #
-  # @param  location [String] the artifact_location
-  # 
-  # @return [Boolean] true when the location is a colon-separated value
-  def from_nexus?(location)
-    !from_http?(location) && location.split(":").length > 2
-  end
-
-  # Returns true when the artifact is believed to be from an
-  # S3 bucket.
-  #
-  # @param  location [String] the artifact_location
-  #
-  # @return [Boolean] true when the location matches s3
-  def from_s3?(location)
-    location =~ URI::regexp('s3')
-  end
-
-  # Convenience method for determining whether a String is "latest"
-  # 
-  # @param  version [String] the version of the configured artifact to check
-  # 
-  # @return [Boolean] true when version matches (case-insensitive) "latest"
-  def latest?(version)
-    version.casecmp("latest") == 0
   end
 
   # Defines a resource call for downloading the remote artifact.

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -56,7 +56,7 @@ def load_current_resource
     group_id, artifact_id, extension = @new_resource.artifact_location.split(':')
     @artifact_version  = Chef::Artifact.get_actual_version(node, [group_id, artifact_id, @new_resource.version, extension].join(':'), @new_resource.ssl_verify)
     @artifact_location = [group_id, artifact_id, artifact_version, extension].join(':')
-  elsif from_s3?(@new_resource.artifact_location)
+  elsif Chef::Artifact.from_s3?(@new_resource.artifact_location)
     unless Chef::Artifact.windows?
       %W{gcc make libxml2 libxslt libxml2-devel libxslt-devel}.each do |nokogiri_requirement|
         package nokogiri_requirement do

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -59,9 +59,9 @@ def load_current_resource
     @artifact_location = [group_id, artifact_id, artifact_version, extension].join(':')
   elsif from_s3?(@new_resource.artifact_location)
     unless Chef::Artifact.windows?
-      %W{libxml2 libxslt libxml2-devel libxslt-devel}.each do |nokogiri_requirement|
+      %W{gcc make libxml2 libxslt libxml2-devel libxslt-devel}.each do |nokogiri_requirement|
         package nokogiri_requirement do
-          action :install
+          action :nothing
         end.run_action(:install)
       end
     end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -21,9 +21,7 @@
 attr_reader :file_location
 
 def load_current_resource
-  @from_nexus = Chef::Artifact.from_nexus?(new_resource.location)
-  @from_s3 = Chef::Artifact.from_s3?(new_resource.location)
-  if from_nexus?
+  if Chef::Artifact.from_nexus?(new_resource.location)
     chef_gem "nexus_cli" do
       version "3.0.0"
     end
@@ -40,7 +38,7 @@ end
 action :create do
   retries = new_resource.download_retries
   begin
-    if from_s3?
+    if Chef::Artifact.from_s3?(new_resource.location)
       unless ::File.exists?(new_resource.name) && checksum_valid?
         Chef::Artifact.retrieve_from_s3(node, new_resource.location, new_resource.name)
       end
@@ -66,7 +64,7 @@ end
 #   matches the checksum on record, false otherwise.
 def checksum_valid?
   require 'digest'
-  if from_nexus?
+  if Chef::Artifact.from_nexus?(new_resource.location)
     Digest::SHA1.file(new_resource.name).hexdigest == Chef::Artifact.get_artifact_sha(node, new_resource.location)
   else
     if new_resource.checksum
@@ -92,14 +90,4 @@ def remote_file_resource
     backup false
     action :nothing
   end
-end
-
-# @return [Boolean]
-def from_nexus?
-  @from_nexus
-end
-
-# @return [Boolean]
-def from_s3?
-  @from_s3
 end

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe Chef::Artifact do
   let(:node) { double('node', chef_environment: "default") }
-
-  describe ":nexus_config_for" do
-    subject { nexus_config_for }
-    let(:nexus_config_for) { described_class.nexus_config_for(node) }
+  describe ":config_for" do
+    subject { config_for }
+    let(:config_for) { described_class.config_for(node, source) }
+    let(:source) { Chef::Artifact::DATA_BAG_NEXUS }
 
     context "when we are using chef-solo" do
       let(:data_bag_item) { {} }
@@ -16,7 +16,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(nexus_config_for).to eq(data_bag_item)
+        expect(config_for).to eq(data_bag_item)
       end
     end
 
@@ -28,8 +28,78 @@ describe Chef::Artifact do
       end
 
       it "loads an encrypted data bag" do
-        expect(nexus_config_for.symbolize_keys).to eq(data_bag_item)
+        expect(config_for.symbolize_keys).to eq(data_bag_item)
       end      
+    end
+
+    context "when loading legacy data bag format" do
+      let(:data_bag_item) { { 'username' => 'nexus_user', 'password' => 'nexus_user_password'} }
+
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+      end
+
+      it "loads a normal data bag" do
+        expect(config_for).to eq(data_bag_item)
+      end
+    end
+
+    context "when loading environment based legacy nexus data bag format" do
+      let(:data_bag_item) { { '*' => { 'username' => 'nexus_user', 'password' => 'nexus_user_password'} } }
+
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+      end
+
+      it "loads a normal data bag" do
+        expect(config_for).to eq(data_bag_item)
+      end
+    end
+
+    context "when loading nexus data bag config" do
+      let(:data_bag_item) { { 'nexus' => { 'username' => 'nexus_user', 'password' => 'nexus_user_password'} } }
+      let(:nexus_data_bag_item) { { 'username' => 'nexus_user', 'password' => 'nexus_user_password'} }
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+      end
+
+      it "loads a normal data bag" do
+        expect(config_for).to eq(nexus_data_bag_item)
+      end
+    end
+
+    context "when loading aws data bag config" do
+      let(:data_bag_item) { {
+            'nexus' => { 'username' => 'nexus_user', 'password' => 'nexus_user_password' },
+            'aws' => { 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' }
+      } }
+      let(:aws_data_bag_item) { { 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' } }
+      let(:source) { Chef::Artifact::DATA_BAG_AWS }
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+      end
+
+      it "loads a normal data bag" do
+        expect(config_for).to eq(aws_data_bag_item)
+      end
+    end
+
+    context "when loading aws data bag config that is not there" do
+      let(:data_bag_item) { {  'nexus' => { 'username' => 'nexus_user', 'password' => 'nexus_user_password' } } }
+      let(:aws_data_bag_item) { { } }
+      let(:source) { Chef::Artifact::DATA_BAG_AWS }
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+      end
+
+      it "loads a normal data bag" do
+        expect(config_for).to eq(aws_data_bag_item)
+      end
     end
   end
 
@@ -100,6 +170,109 @@ describe Chef::Artifact do
 
       it "raises a DataBagEncryptionError" do
         expect{ encrypted_data_bag_item }.to raise_error(Chef::Artifact::DataBagEncryptionError)
+      end
+    end
+  end
+
+  describe ":retrieve_from_s3" do
+    require 'aws-sdk'
+
+    subject { retrieve_from_s3 }
+    let(:retrieve_from_s3) { described_class.retrieve_from_s3(node, "s3://my-bucket/my-file.tar.gz", "filename") }
+    let(:mock_s3_client) { mock('mock_s3_client') }
+    let(:mock_output_file) { mock('mock_output_file') }
+    let(:mock_s3_bucket) { mock('my-bucket') }
+    let(:mock_s3_object) { mock('my-file.tar.gz') }
+    let(:stub_buckets_list) { stub('s3buckets') }
+    let(:stub_objects_list) { stub('s3ojects') }
+    let(:mock_file_contents) { 'test file contents' }
+    let(:expected_file_contents) { 'test file contents' }
+
+    context "when getting a valid file from S3" do
+      let(:data_bag_item) { { 'aws' => { 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' } } }
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+        AWS::S3.should_receive(:new).with({:access_key_id=>"my_access_key", :secret_access_key=>"my_secret_key"}).and_return(mock_s3_client)
+        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
+      end
+
+      it "loads a normal data bag" do
+        stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
+        stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
+
+        mock_s3_client.should_receive(:buckets).twice.and_return(stub_buckets_list)
+        mock_s3_bucket.should_receive(:objects).twice.and_return(stub_objects_list)
+        mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
+        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(true)
+        stub_objects_list.should_receive(:has_key?).with('my-file.tar.gz').and_return(true)
+        mock_output_file.should_receive(:size).and_return(11241)
+        mock_output_file.should_receive(:write).with(expected_file_contents)
+
+        retrieve_from_s3
+      end
+    end
+
+    context "when getting a valid file from S3 using IAM role" do
+      let(:data_bag_item) { { } }
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+        AWS::S3.should_receive(:new).with(no_args()).and_return(mock_s3_client)
+        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
+      end
+
+      it "loads a normal data bag" do
+        stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
+        stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
+
+        mock_s3_client.should_receive(:buckets).twice.and_return(stub_buckets_list)
+        mock_s3_bucket.should_receive(:objects).twice.and_return(stub_objects_list)
+        mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
+        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(true)
+        stub_objects_list.should_receive(:has_key?).with('my-file.tar.gz').and_return(true)
+        mock_output_file.should_receive(:size).and_return(11241)
+        mock_output_file.should_receive(:write).with(expected_file_contents)
+
+        retrieve_from_s3
+      end
+    end
+
+    context "when asking for an S3 bucket that does not exist" do
+      let(:data_bag_item) { { } }
+
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+        AWS::S3.should_receive(:new).with(no_args()).and_return(mock_s3_client)
+      end
+
+      it "throws an S3BucketNotFoundError" do
+        mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
+        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(false)
+
+        expect{ retrieve_from_s3 }.to raise_error(Chef::Artifact::S3BucketNotFoundError)
+      end
+    end
+
+    context "when asking for an S3 object that does not exist" do
+      let(:data_bag_item) { { } }
+
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+        AWS::S3.should_receive(:new).with(no_args()).and_return(mock_s3_client)
+      end
+
+      it "throws an S3ArtifactNotFoundError" do
+        stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
+
+        mock_s3_client.should_receive(:buckets).twice.and_return(stub_buckets_list)
+        mock_s3_bucket.should_receive(:objects).and_return(stub_objects_list)
+        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(true)
+        stub_objects_list.should_receive(:has_key?).with('my-file.tar.gz').and_return(false)
+
+        expect{ retrieve_from_s3 }.to raise_error(Chef::Artifact::S3ArtifactNotFoundError)
       end
     end
   end

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -174,6 +174,34 @@ describe Chef::Artifact do
     end
   end
 
+  describe ":from_http?" do
+    specify { described_class.from_http?('s3://my.bucket/a/valid/file.tar.gz').should eq(false) }
+    specify { described_class.from_http?('http://files3.something.com').should eq(true) }
+    specify { described_class.from_http?('https://artifacts.location.riotgames.com/pvpnet-1.0.0.tar.gz').should eq(true) }
+    specify { described_class.from_http?('https://s3-us-west-2.amazonaws.com/my.bucket/a/valid/file.tar.gz').should eq(true) }
+    specify { described_class.from_http?('ftp://someserver.example.com/file.tgz').should eq(false) }
+  end
+
+  describe ":from_nexus?" do
+    specify { described_class.from_nexus?('s3://my.bucket/a/valid/file.tar.gz').should eq(false) }
+    specify { described_class.from_nexus?('http://files3.something.com').should eq(false) }
+    specify { described_class.from_nexus?('https://s3-us-west-2.amazonaws.com/my.bucket/a/valid/file.tar.gz').should eq(false) }
+    specify { described_class.from_nexus?('ftp://someserver.example.com/file.tgz').should eq(false) }
+    specify { described_class.from_nexus?('com.foo:my-artifact:tgz').should eq(true) }
+  end
+
+  describe ":from_s3?" do
+    specify { described_class.from_s3?('s3://my.bucket/a/valid/file.tar.gz').should eq(true) }
+    specify { described_class.from_s3?('http://files3.something.com').should eq(false) }
+    specify { described_class.from_s3?('https://s3-us-west-2.amazonaws.com/my.bucket/a/valid/file.tar.gz').should eq(false) }
+  end
+
+  describe ":latest?" do
+    specify { described_class.latest?('latest').should eq(true) }
+    specify { described_class.latest?('LAtest').should eq(true) }
+    specify { described_class.latest?('3.0.1').should eq(false) }
+  end
+
   describe ":retrieve_from_s3" do
     require 'aws-sdk'
 

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -201,11 +201,11 @@ describe Chef::Artifact do
         stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
         stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
 
-        mock_s3_client.should_receive(:buckets).twice.and_return(stub_buckets_list)
-        mock_s3_bucket.should_receive(:objects).twice.and_return(stub_objects_list)
+        mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
+        mock_s3_bucket.should_receive(:objects).and_return(stub_objects_list)
+        mock_s3_bucket.should_receive(:exists?).and_return(true)
         mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
-        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(true)
-        stub_objects_list.should_receive(:has_key?).with('my-file.tar.gz').and_return(true)
+        mock_s3_object.should_receive(:exists?).and_return(true)
         mock_output_file.should_receive(:size).and_return(11241)
         mock_output_file.should_receive(:write).with(expected_file_contents)
 
@@ -226,11 +226,11 @@ describe Chef::Artifact do
         stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
         stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
 
-        mock_s3_client.should_receive(:buckets).twice.and_return(stub_buckets_list)
-        mock_s3_bucket.should_receive(:objects).twice.and_return(stub_objects_list)
+        mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
+        mock_s3_bucket.should_receive(:objects).and_return(stub_objects_list)
+        mock_s3_bucket.should_receive(:exists?).and_return(true)
         mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
-        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(true)
-        stub_objects_list.should_receive(:has_key?).with('my-file.tar.gz').and_return(true)
+        mock_s3_object.should_receive(:exists?).and_return(true)
         mock_output_file.should_receive(:size).and_return(11241)
         mock_output_file.should_receive(:write).with(expected_file_contents)
 
@@ -248,8 +248,10 @@ describe Chef::Artifact do
       end
 
       it "throws an S3BucketNotFoundError" do
+        stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
+
         mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
-        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(false)
+        mock_s3_bucket.should_receive(:exists?).and_return(false)
 
         expect{ retrieve_from_s3 }.to raise_error(Chef::Artifact::S3BucketNotFoundError)
       end
@@ -266,11 +268,12 @@ describe Chef::Artifact do
 
       it "throws an S3ArtifactNotFoundError" do
         stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
+        stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
 
-        mock_s3_client.should_receive(:buckets).twice.and_return(stub_buckets_list)
+        mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
         mock_s3_bucket.should_receive(:objects).and_return(stub_objects_list)
-        stub_buckets_list.should_receive(:has_key?).with('my-bucket').and_return(true)
-        stub_objects_list.should_receive(:has_key?).with('my-file.tar.gz').and_return(false)
+        mock_s3_bucket.should_receive(:exists?).and_return(true)
+        mock_s3_object.should_receive(:exists?).and_return(false)
 
         expect{ retrieve_from_s3 }.to raise_error(Chef::Artifact::S3ArtifactNotFoundError)
       end

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Chef::Artifact do
   let(:node) { double('node', chef_environment: "default") }
-  describe ":config_for" do
-    subject { config_for }
-    let(:config_for) { described_class.config_for(node, source) }
+  describe ":data_bag_config_for" do
+    subject { data_bag_config_for }
+    let(:data_bag_config_for) { described_class.data_bag_config_for(node, source) }
     let(:source) { Chef::Artifact::DATA_BAG_NEXUS }
 
     context "when we are using chef-solo" do
@@ -16,7 +16,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(config_for).to eq(data_bag_item)
+        expect(data_bag_config_for).to eq(data_bag_item)
       end
     end
 
@@ -28,7 +28,7 @@ describe Chef::Artifact do
       end
 
       it "loads an encrypted data bag" do
-        expect(config_for.symbolize_keys).to eq(data_bag_item)
+        expect(data_bag_config_for.symbolize_keys).to eq(data_bag_item)
       end      
     end
 
@@ -41,7 +41,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(config_for).to eq(data_bag_item)
+        expect(data_bag_config_for).to eq(data_bag_item)
       end
     end
 
@@ -54,7 +54,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(config_for).to eq(data_bag_item)
+        expect(data_bag_config_for).to eq(data_bag_item)
       end
     end
 
@@ -67,7 +67,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(config_for).to eq(nexus_data_bag_item)
+        expect(data_bag_config_for).to eq(nexus_data_bag_item)
       end
     end
 
@@ -84,7 +84,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(config_for).to eq(aws_data_bag_item)
+        expect(data_bag_config_for).to eq(aws_data_bag_item)
       end
     end
 
@@ -98,7 +98,7 @@ describe Chef::Artifact do
       end
 
       it "loads a normal data bag" do
-        expect(config_for).to eq(aws_data_bag_item)
+        expect(data_bag_config_for).to eq(aws_data_bag_item)
       end
     end
   end


### PR DESCRIPTION
I put together support to pull deployment artifacts from S3 in addition to Nexus, local files and URLs.  This is based entirely on the url provided - S3 artifacts must be in the form: `s3://bucket-name/path/to/object`

Included in this is a change to the format of the data_bags - I made it backwards compatible to current and previous formats, and wrote rspec tests around it as well.

I am fairly new to Ruby (and never done rspec tests before) - so suggestions or comments are welcome!
