### PR TITLE
read ssl_verify from the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ migrate                    | A proc containing resources to be executed during t
 after_migrate              | A proc containing resources to be executed after the migration Proc                  | Proc    |
 restart                    | A proc containing resources to be executed at the end of a successful deploy         | Proc    |
 after_deploy               | A proc containing resources to be executed after the deploy process ends             | Proc    |
-ssl_verify                 | Used to set whether or not communications with a Nexus server should be SSL verified | Boolean | true
 remove_top_level_directory | Deletes a top level directory from the extracted zip file                            | Boolean | false
 skip_manifest_check        | Skips the manifest check for idempotency when the version attribute is not changing  | Boolean | false 
 remove_on_force            | Removes the current version directory contents when force is set                     | Boolean | false

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -76,21 +76,19 @@ class Chef
       # 
       # @param  node [Chef::Node] the node
       # @param  artifact_location [String] a colon-separated Maven identifier string that represents the artifact
-      # @param  ssl_verify [Boolean] a boolean to pass through to the NexusCli::RemoteFactory#create method. This
-      #   is a TERRIBLE IDEA and you should never want to set this to false!
       # 
       # @example
       #   Chef::Artifact.get_actual_version(node, "com.myartifact:my-artifact:latest:tgz") => "2.0.5"
       #   Chef::Artifact.get_actual_version(node, "com.myartifact:my-artifact:1.0.1:tgz")  => "1.0.1"
       # 
       # @return [String] the version number that latest resolves to or the passed in value
-      def get_actual_version(node, artifact_location, ssl_verify=true)
+      def get_actual_version(node, artifact_location)
         version = artifact_location.split(':')[2]
         if version.casecmp("latest") == 0
           require 'nexus_cli'
           require 'rexml/document'
           config = nexus_config_for(node)
-          remote = NexusCli::RemoteFactory.create(config, ssl_verify)
+          remote = NexusCli::RemoteFactory.create(config, config[:ssl_verify])
           REXML::Document.new(remote.get_artifact_info(artifact_location)).elements["//version"].text
         else
           version
@@ -142,14 +140,13 @@ class Chef
       #
       # @param  node [Chef::Node] the node
       # @param  artifact_location [String] a colon-separated Maven identifier that represents the artifact
-      # @param  ssl_verify=true [Boolean] whether or not ssl methods will be verified
       #
       # @return [String] the SHA1 entry for the artifact
-      def get_artifact_sha(node, artifact_location, ssl_verify=true)
+      def get_artifact_sha(node, artifact_location)
         require 'nexus_cli'
         require 'rexml/document'
         config = nexus_config_for(node)
-        remote = NexusCli::RemoteFactory.create(config, ssl_verify)
+        remote = NexusCli::RemoteFactory.create(config, config[:ssl_verify])
         REXML::Document.new(remote.get_artifact_info(artifact_location)).elements["//sha1"].text
       end
 

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -55,7 +55,7 @@ def load_current_resource
     end
 
     group_id, artifact_id, extension = @new_resource.artifact_location.split(':')
-    @artifact_version  = Chef::Artifact.get_actual_version(node, [group_id, artifact_id, @new_resource.version, extension].join(':'), @new_resource.ssl_verify)
+    @artifact_version  = Chef::Artifact.get_actual_version(node, [group_id, artifact_id, @new_resource.version, extension].join(':'))
     @artifact_location = [group_id, artifact_id, artifact_version, extension].join(':')
   else
     @artifact_version = @new_resource.version

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -50,7 +50,6 @@ attribute :after_migrate, :kind_of      => Proc
 attribute :migrate, :kind_of            => Proc
 attribute :restart, :kind_of            => Proc
 attribute :after_deploy, :kind_of       => Proc
-attribute :ssl_verify, :kind_of         => [ TrueClass, FalseClass ], :default => true
 attribute :remove_top_level_directory, :kind_of => [ TrueClass, FalseClass ], :default => false
 attribute :skip_manifest_check, :kind_of => [ TrueClass, FalseClass ], :default => false
 attribute :remove_on_force, :kind_of => [ TrueClass, FalseClass ], :default => false


### PR DESCRIPTION
ssl_verify defaults to true in the nexus_cli gem. So remove most of the references to it from artifact-cookbook. Then allow ssl_verify to be configured via the data bag, so that you can override it globally.
