### PR TITLE
Use basic auth when anonymous access is disabled on the nexus server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Provides your cookbooks with the Artifact Deploy LWRP
 
 With Vagrant 1.1, there is no longer a Vagrant RubyGem to install. Instead, follow the instructions on the [VagrantUp](http://docs.vagrantup.com/v2/installation/index.html) documentation pages.
 
+# Attributes
+
+Attribute                          | Description                                                                          | Default
+---------------------------------- |------------------------------------------------------------------------------------- |--------
+artifact.nexus.basic_auth_required | Set to true if the Nexus server requires basic authentication for file downloads. | false
+
 # Resources / Providers
 
 ## artifact_deploy

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default[:artifact][:nexus][:basic_auth_required] = true

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -219,6 +219,12 @@ class Chef
         REXML::Document.new(remote.get_artifact_info(artifact_location)).elements["//sha1"].text
       end
 
+      # Checks the nexus server to see if the anonymous user is enabled
+      #
+      # @param node [Chef::Node] the node
+      # @param  ssl_verify=true [Boolean] whether or not ssl methods will be verified
+      #
+      # @return [Boolean]
       def anonymous_enabled?(node, ssl_verify=true)
         # TODO extract remote
         require 'nexus_cli'

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -192,7 +192,15 @@ class Chef
         query_string = "g=#{group_id}&a=#{artifact_id}&v=#{version}&e=#{extension}&r=#{config['repository']}"
         uri_for_url = URI(config['url'])
         builder = uri_for_url.scheme =~ /https/ ? URI::HTTPS : URI::HTTP
-        builder.build(host: uri_for_url.host, port: uri_for_url.port, path: '/nexus/service/local/artifact/maven/redirect', query: query_string).to_s
+        builder_options = {
+          host: uri_for_url.host, 
+          port: uri_for_url.port, 
+          path: '/nexus/service/local/artifact/maven/redirect', 
+          query: query_string
+        }
+        builder_options[:userinfo] = "#{config['username']}:#{config['password']}" if node[:artifact][:nexus][:basic_auth_required]
+
+        builder.build(builder_options).to_s
       end
 
       # Makes a call to Nexus and parses the returned XML to return

--- a/libraries/chef_artifact_errors.rb
+++ b/libraries/chef_artifact_errors.rb
@@ -40,6 +40,14 @@ class Chef
       end
     end
 
+    class ArtifactDownloadError < ArtifactError
+      attr_accessor :message
+
+      def initialize(message)
+        @message = message
+      end
+    end
+
     class S3BucketNotFoundError < ArtifactError
       attr_reader :bucket_name
 

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -567,6 +567,7 @@ private
       owner new_resource.owner
       group new_resource.group
       checksum new_resource.artifact_checksum
+      ssl_verify new_resource.ssl_verify
       action :create
     end
   end
@@ -579,6 +580,7 @@ private
       location artifact_location
       owner new_resource.owner
       group new_resource.group
+      ssl_verify new_resource.ssl_verify
       action :create
     end
   end
@@ -592,6 +594,7 @@ private
       owner new_resource.owner
       group new_resource.group
       checksum new_resource.artifact_checksum
+      ssl_verify new_resource.ssl_verify
       action :create
     end
   end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -48,7 +48,7 @@ action :create do
           remote_file_resource.run_action(:create)
         rescue Net::HTTPServerException => e
           if e.to_s =~ /401/
-            msg = "The artifact server returned 401, Unauthorized when attempting to retrieve this artifact. Confirm that your credentials are configured correctly."
+            msg = "The artifact server returned 401 (Unauthorized) when attempting to retrieve this artifact. Confirm that your credentials are correct."
 
             raise Chef::Artifact::ArtifactDownloadError.new(msg)
           else

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -27,4 +27,5 @@ attribute :location, :kind_of => String
 attribute :checksum, :kind_of  => String
 attribute :owner, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]
+attribute :ssl_verify, :kind_of => [ TrueClass, FalseClass ], :default => true
 attribute :download_retries, :kind_of => Integer, :default => 1


### PR DESCRIPTION
Allows basic auth to be used for nexus artifact retrieval.
