### PR TITLE
Fix S3 code to support all regions (and not just US Standard buckets)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gem 'test-kitchen', git: 'git@github.com:opscode/test-kitchen.git'
 gem 'kitchen-vagrant', :group => :integration
 gem 'rspec'
 gem 'chef', '~> 10.18'
-gem 'aws-sdk', '= 1.11.0'
+gem 'aws-sdk', '= 1.15.0'

--- a/README.md
+++ b/README.md
@@ -207,9 +207,15 @@ separate data_bag items:
 
 #### S3 Usage
 
-S3 can be used as a source of an archive.  The location path must be in the form ```s3://bucket-name/path/to/archive.tar.gz```.  You can provide AWS credentials in the data_bag,
+S3 can be used as a source of an archive.  The location path must be in the form ```s3://s3-endpoint/bucket-name/path/to/archive.tar.gz```.  You can provide AWS credentials in the data_bag,
 or if you are running on EC2 and are using IAM Instance Roles - you may omit the credentials and use the Instance Role. Alternatively, if the credentials are available on the
 environment they will be used from there (more information on the Environment variable keys an be found <http://docs.aws.amazon.com/AWSSdkDocsRuby/latest/DeveloperGuide/ruby-dg-roles.html>).
+
+The S3 endpoints are documented here <http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region>.
+
+If you want to retrieve an object from an S3 bucket in the US-Standard region - use the following format: ```s3://s3.amazonaws.com/bucket-name/path/to/archive.tar.gz```.
+
+If you want to retrieve and object from a bucket in the US West (Oregon) Region region ```s3://s3-us-west-2.amazonaws.com/bucket-name/path/to/archive.tar.gz``` or EU (Ireland) Region:  ```s3://s3-eu-west-1.amazonaws.com/bucket-name/path/to/archive.tar.gz```
 
 This is example IAM policy to get an artifact from S3. Note that this policy will limit permissions to just the files contained under the ```deploys/``` path.
 If you wish to keep them in the root of your bucket, just omit the ```deploys/``` portion and put ```<your-s3-bucket>/*```:
@@ -355,7 +361,7 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
 
     artifact_deploy "my-artifact" do
       version           "1.0.0"
-      artifact_location "s3://my-website-deployments/deploys/my-artifact-1.0.0.tgz"
+      artifact_location "s3://s3.amazonaws.com/my-website-deployments/deploys/my-artifact-1.0.0.tgz"
       deploy_to         "/srv/my-artifact"
       owner             node[:artifact_owner]
       group             node[:artifact_group]
@@ -404,7 +410,7 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
 ##### Using artifact_file to download a file from an S3 bucket
 
     artifact_file "/tmp/my-artifact.tgz" do
-      location "s3://my-website-deployments/deploys/my-artifact-1.0.0.tgz"
+      location "s3://s3.amazonaws.com/my-website-deployments/deploys/my-artifact-1.0.0.tgz"
       owner "me"
       group "mes"
       checksum "fcb188ed37d41ff2cbf1a52d3a11bfde666e036b5c7ada1496dc1d53dd6ed5dd"

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -143,10 +143,17 @@ class Chef
         begin
           require 'aws-sdk'
           config = data_bag_config_for(node, DATA_BAG_AWS)
-          s3_region, bucket_name, object_name = parse_s3_url(source_file)
+          s3_endpoint, bucket_name, object_name = parse_s3_url(source_file)
 
-          s3_client = configure_s3_client(config, s3_region)
-          object = get_s3_object(s3_client, bucket_name, object_name)
+          if config.empty?
+            AWS.config(:s3 => { :endpoint => s3_endpoint })
+          else
+            AWS.config(:access_key_id => config['access_key_id'],
+                       :secret_access_key => config['secret_access_key'],
+                       :s3 => { :endpoint => s3_endpoint })
+          end
+
+          object = get_s3_object(bucket_name, object_name)
 
           Chef::Log.debug("Downloading #{object_name} from S3 bucket #{bucket_name}")
           ::File.open(destination_file, 'w') do |file|
@@ -161,56 +168,33 @@ class Chef
         end
       end
 
-      # Create an AWS::S3 client that is configured with AWS Credentials (if provided in the data_bag) and the correct
-      # AWS region for the bucket being accessed.  If no AWS credentials are provided in the data_bag, it will assume
-      # the machine has an IAM Instance Profile available to get credentials from.
+      # Parse a source url to retrieve the specific parts required to interact with the object on S3.
       #
       # @example
-      #   s3_client = Chef::Artifact.configure_s3_client({:access_key_id =>'access-key', :secret_access_key => 'secret-key'}, 'us-west-2')
-      #
-      # @param  config [Hash] Data bag configuration to load credentials from
-      # @param  s3_region [String] S3 Region to connect to
-      #
-      # @return [AWS::S3] An S3 client object that has been configured with credentials (if provided) for the correct region
-      def configure_s3_client(config, s3_region)
-        unless config.empty?
-          AWS.config(:access_key_id => config['access_key_id'], :secret_access_key => config['secret_access_key'])
-        end
-        AWS::S3.new(:region => s3_region)
-      end
-
-      # Parse a source url to retrieve the specific parts required to interact with the object on S3.  This method
-      # will also convert the s3 endpoint in the URL to the correct AWS Region.
-      #
-      # @example
-      #   s3_region, bucket_name, object_name = Chef::Artifact.parse_s3_url('s3://s3.amazonaws.com/my-bucket/my-file.txt')
+      #   s3_endpoint, bucket_name, object_name = Chef::Artifact.parse_s3_url('s3://s3.amazonaws.com/my-bucket/my-file.txt')
       #
       # @param  source_url [String] Source url to parse
       #
-      # @return [Array] An array containing the S3 Region, Bucket Name and Object Name
+      # @return [Array] An array containing the S3 endpoint, Bucket Name and Object Name
       def parse_s3_url(source_url)
         protocol, s3_endpoint, bucket_and_object = URI.split(source_url).compact
-        s3_region = 'us-east-1'  # default region
-        AWS.regions.each do |region|
-          s3_region = region.name if region.s3.client.endpoint == s3_endpoint
-        end
         path_parts = bucket_and_object[1..-1].split('/')
         bucket_name = path_parts[0]
         object_name = path_parts[1..-1].join('/')
-        [s3_region, bucket_name, object_name]
+        [s3_endpoint, bucket_name, object_name]
       end
 
-      # Given an s3_client, bucket name and object name - fetches the object from S3
+      # Given a bucket and object name - fetches the object from S3
       #
       # @example
-      #   object = Chef::Artifact.get_s3_object(s3_client, 'my-bucket', 'my-file.txt')
+      #   object = Chef::Artifact.get_s3_object('my-bucket', 'my-file.txt')
       #
-      # @param  s3_client [AWS::S3]
       # @param  bucket_name [String] Name of the S3 bucket
       # @param  object_name [String] Name of the S3 object
       #
       # @return [AWS::S3::S3Object] An S3 Object
-      def get_s3_object(s3_client, bucket_name, object_name)
+      def get_s3_object(bucket_name, object_name)
+        s3_client = AWS::S3.new()
         bucket = s3_client.buckets[bucket_name]
         raise S3BucketNotFoundError.new(bucket_name) unless bucket.exists?
 

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -191,7 +191,8 @@ describe Chef::Artifact do
   end
 
   describe ":from_s3?" do
-    specify { described_class.from_s3?('s3://my.bucket/a/valid/file.tar.gz').should eq(true) }
+    specify { described_class.from_s3?('s3://s3.amazonaws.com/my.bucket/a/valid/file.tar.gz').should eq(true) }
+    specify { described_class.from_s3?('s3://s3-us-west-2.amazonaws.com/my.bucket/a/valid/file.tar.gz').should eq(true) }
     specify { described_class.from_s3?('http://files3.something.com').should eq(false) }
     specify { described_class.from_s3?('https://s3-us-west-2.amazonaws.com/my.bucket/a/valid/file.tar.gz').should eq(false) }
   end
@@ -202,98 +203,43 @@ describe Chef::Artifact do
     specify { described_class.latest?('3.0.1').should eq(false) }
   end
 
-  describe ":retrieve_from_s3" do
+  describe ":get_s3_object" do
     require 'aws-sdk'
-
-    subject { retrieve_from_s3 }
-    let(:retrieve_from_s3) { described_class.retrieve_from_s3(node, "s3://my-bucket/my-file.tar.gz", "filename") }
+    AWS.stub!
+    subject { get_s3_object }
     let(:mock_s3_client) { mock('mock_s3_client') }
-    let(:mock_output_file) { mock('mock_output_file') }
     let(:mock_s3_bucket) { mock('my-bucket') }
     let(:mock_s3_object) { mock('my-file.tar.gz') }
     let(:stub_buckets_list) { stub('s3buckets') }
     let(:stub_objects_list) { stub('s3ojects') }
-    let(:mock_file_contents) { 'test file contents' }
-    let(:expected_file_contents) { 'test file contents' }
+    let(:get_s3_object) { described_class.get_s3_object(mock_s3_client, 'my-bucket', 'my-file.tar.gz') }
 
-    context "when getting a valid file from S3" do
-      let(:data_bag_item) { { 'aws' => { 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' } } }
-      before do
-        Chef::Config.stub(:[]).and_return({solo: true})
-        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
-        AWS::S3.should_receive(:new).with({:access_key_id=>"my_access_key", :secret_access_key=>"my_secret_key"}).and_return(mock_s3_client)
-        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
-      end
-
-      it "loads a normal data bag" do
+    context "when getting an object from S3" do
+      it "loads file normally" do
         stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
         stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
 
         mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
         mock_s3_bucket.should_receive(:objects).and_return(stub_objects_list)
         mock_s3_bucket.should_receive(:exists?).and_return(true)
-        mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
         mock_s3_object.should_receive(:exists?).and_return(true)
-        mock_output_file.should_receive(:size).and_return(11241)
-        mock_output_file.should_receive(:write).with(expected_file_contents)
 
-        retrieve_from_s3
-      end
-    end
-
-    context "when getting a valid file from S3 using IAM role" do
-      let(:data_bag_item) { { } }
-      before do
-        Chef::Config.stub(:[]).and_return({solo: true})
-        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
-        AWS::S3.should_receive(:new).with(no_args()).and_return(mock_s3_client)
-        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
-      end
-
-      it "loads a normal data bag" do
-        stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
-        stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
-
-        mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
-        mock_s3_bucket.should_receive(:objects).and_return(stub_objects_list)
-        mock_s3_bucket.should_receive(:exists?).and_return(true)
-        mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
-        mock_s3_object.should_receive(:exists?).and_return(true)
-        mock_output_file.should_receive(:size).and_return(11241)
-        mock_output_file.should_receive(:write).with(expected_file_contents)
-
-        retrieve_from_s3
+        get_s3_object
       end
     end
 
     context "when asking for an S3 bucket that does not exist" do
-      let(:data_bag_item) { { } }
-
-      before do
-        Chef::Config.stub(:[]).and_return({solo: true})
-        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
-        AWS::S3.should_receive(:new).with(no_args()).and_return(mock_s3_client)
-      end
-
       it "throws an S3BucketNotFoundError" do
         stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
 
         mock_s3_client.should_receive(:buckets).and_return(stub_buckets_list)
         mock_s3_bucket.should_receive(:exists?).and_return(false)
 
-        expect{ retrieve_from_s3 }.to raise_error(Chef::Artifact::S3BucketNotFoundError)
+        expect{ get_s3_object }.to raise_error(Chef::Artifact::S3BucketNotFoundError)
       end
     end
 
     context "when asking for an S3 object that does not exist" do
-      let(:data_bag_item) { { } }
-
-      before do
-        Chef::Config.stub(:[]).and_return({solo: true})
-        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
-        AWS::S3.should_receive(:new).with(no_args()).and_return(mock_s3_client)
-      end
-
       it "throws an S3ArtifactNotFoundError" do
         stub_buckets_list.stub(:[]).with('my-bucket').and_return(mock_s3_bucket)
         stub_objects_list.stub(:[]).with('my-file.tar.gz').and_return(mock_s3_object)
@@ -303,7 +249,67 @@ describe Chef::Artifact do
         mock_s3_bucket.should_receive(:exists?).and_return(true)
         mock_s3_object.should_receive(:exists?).and_return(false)
 
-        expect{ retrieve_from_s3 }.to raise_error(Chef::Artifact::S3ArtifactNotFoundError)
+        expect{ get_s3_object }.to raise_error(Chef::Artifact::S3ArtifactNotFoundError)
+      end
+    end
+  end
+
+  describe ":configure_s3_client" do
+    require 'aws-sdk'
+    AWS.stub!
+    subject { configure_s3_client }
+
+    context "when configuring an s3 client with data_bag credentials" do
+      let(:config) { { 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' } }
+      it "uses the access_key_id and secret_access_key" do
+        AWS.should_receive(:config).with({:access_key_id=>"my_access_key", :secret_access_key=>"my_secret_key"})
+        AWS::S3.should_receive(:new).with({:region => 'us-east-1'})
+        Chef::Artifact.configure_s3_client(config, 'us-east-1')
+      end
+    end
+
+    context "when configuring an s3 client with no credentials" do
+      let(:config) { { } }
+      it "provides no credentials" do
+        AWS.should_not_receive(:config)
+        AWS::S3.should_receive(:new).with({:region => 'us-east-1'})
+        Chef::Artifact.configure_s3_client(config, 'us-east-1')
+      end
+    end
+  end
+
+  describe ":retrieve_from_s3" do
+    require 'aws-sdk'
+    AWS.stub!
+    subject { retrieve_from_s3 }
+    let(:mock_s3_client) { mock('mock_s3_client') }
+    let(:mock_output_file) { mock('mock_output_file') }
+    let(:mock_s3_bucket) { mock('my-bucket') }
+    let(:mock_s3_object) { mock('my-file.tar.gz') }
+    let(:stub_buckets_list) { stub('s3buckets') }
+    let(:stub_objects_list) { stub('s3ojects') }
+    let(:mock_file_contents) { 'test file contents' }
+    let(:expected_file_contents) { 'test file contents' }
+
+    context "when getting a valid file from S" do
+      let(:data_bag_item) { { 'aws' => { 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' } } }
+      before do
+        Chef::Config.stub(:[]).and_return({solo: true})
+        Chef::DataBagItem.stub(:load).and_return(data_bag_item)
+        described_class.should_receive(:configure_s3_client).with({ 'access_key_id' => 'my_access_key', 'secret_access_key' => 'my_secret_key' }, 'us-east-1').and_return(mock_s3_client)
+        described_class.should_receive(:get_s3_object).with(mock_s3_client, "my-bucket", "my-file.tar.gz").and_return(mock_s3_object)
+        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
+      end
+
+      it "loads a normal data bag" do
+        stub_buckets_list.stub(:[]).with("my-bucket").and_return(mock_s3_bucket)
+        stub_objects_list.stub(:[]).with("my-file.tar.gz").and_return(mock_s3_object)
+
+        mock_s3_object.should_receive(:read).and_yield(mock_file_contents)
+        mock_output_file.should_receive(:size).and_return(11241)
+        mock_output_file.should_receive(:write).with(expected_file_contents)
+
+        Chef::Artifact.retrieve_from_s3(node, "s3://s3.amazonaws.com/my-bucket/my-file.tar.gz", "filename")
       end
     end
   end


### PR DESCRIPTION
I managed to write the S3 code to only work against the US Standard buckets.  I've fixed it to properly support all AWS regions.  

There is a change in the format of the S3 source urls that will cause users to have to update their usage.

Previously URLs were in the form:

```
s3://bucket-name/filename.tar.gz
```

Now the URLs will need to include the S3 region endpoint:

```
s3://s3.amazonaws.com/bucket-name/filename.tar.gz  # for a US Standard bucket 
s3://s3-us-west-2.amazonaws.com/bucket-name/filename.tar.gz # for a bucket in US West (Oregon) region.
```
