### PR TITLE
Add support for Maven artifact classifers

### DIFF
--- a/libraries/chef_artifact_nexus.rb
+++ b/libraries/chef_artifact_nexus.rb
@@ -27,8 +27,8 @@ class Chef
       #
       # @return [String] the version number that latest resolves to or the passed in value
       def get_actual_version(coordinates)
-        version = coordinates.split(':')[3]
-        if Chef::Artifact.latest?(version)
+        artifact = NexusCli::Artifact.new(coordinates)
+        if Chef::Artifact.latest?(artifact.version)
           REXML::Document.new(remote.get_artifact_info(coordinates)).elements["//version"].text
         else
           version


### PR DESCRIPTION
Replaces brittle splitting/joining with parsing of coordinates by `nexus_cli`. Support for classifiers is mostly a side-effect.

The addition of a method similar to `NexusCli::Artifact:file_name` based on `providers/deploy.rb:63-67` would make the code here completely classifier ignorant.
