### PR TITLE
Attempt to load manifest first

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
 #### Using artifact_file to download a file from Nexus
 
     artifact_file "/tmp/my-artifact.tgz" do
-      location "com.test:my-artifact:1.0.0:tgz"
+      location "com.test:my-artifact:tgz:1.0.0"
       owner "me"
       group "mes"
       action :create
@@ -451,6 +451,24 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
       group "mes"
       checksum "fcb188ed37d41ff2cbf1a52d3a11bfde666e036b5c7ada1496dc1d53dd6ed5dd"
       action :create
+    end
+
+##### Using artifact_package to install an rpm from a website
+
+    artifact_package "tomcat" do
+      location "http://my-website/tomcat-5.0.rpm"
+      owner "me"
+      group "mes"
+      action :install
+    end
+
+##### Using artifact_package to install an rpm from Nexus
+
+    artifact_package "tomcat" do
+      location "com.rpm:tomcat:rpm:6.0.0"
+      owner "me"
+      group "mes"
+      action :install
     end
 
 # Testing

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -387,17 +387,17 @@ private
   def has_manifest_changed?
     require 'active_support/core_ext/hash'
 
-    if skip_manifest_check?
-      Chef::Log.debug "artifact_deploy[has_manifest_changed?] Skip Manifest Check attribute is true. Skipping manifest check."
-      return false
-    end
-
     Chef::Log.debug "artifact_deploy[has_manifest_changed?] Loading manifest.yaml file from directory: #{release_path}"
     begin
       saved_manifest = YAML.load_file(::File.join(release_path, "manifest.yaml"))
     rescue Errno::ENOENT
       Chef::Log.warn "artifact_deploy[has_manifest_changed?] Cannot load manifest.yaml. It may have been deleted. Deploying."
       return true
+    end
+
+    if skip_manifest_check?
+      Chef::Log.debug "artifact_deploy[has_manifest_changed?] Skip Manifest Check attribute is true. Skipping manifest check."
+      return false
     end
 
     current_manifest = generate_manifest(release_path)


### PR DESCRIPTION
If we have a crash during artifact_deploy, and we believe the artifact has already been deployed checking the manifest can incorrectly report false when `skip_manifest_check` is true. We should probably attempt to load the manifest first, then skip checking it or check it depending on whether or not the manifest was found.
