### PR TITLE
Remove Activesupport

### DIFF
--- a/libraries/activesupport_hash_diff.rb
+++ b/libraries/activesupport_hash_diff.rb
@@ -1,5 +1,26 @@
 # All credit given to Activesupport
 # https://github.com/rails/rails/blob/v3.2.13/activesupport/lib/active_support/core_ext/hash/diff.rb
+# 
+# Copyright (c) 2005-2011 David Heinemeier Hansson
+# 
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 class Hash
   def diff(h2)
     self.dup.delete_if { |k, v| h2[k] == v }.merge(h2.dup.delete_if { |k, v| self.has_key?(k) })

--- a/libraries/activesupport_hash_diff.rb
+++ b/libraries/activesupport_hash_diff.rb
@@ -1,0 +1,7 @@
+# All credit given to Activesupport
+# https://github.com/rails/rails/blob/v3.2.13/activesupport/lib/active_support/core_ext/hash/diff.rb
+class Hash
+  def diff(h2)
+    self.dup.delete_if { |k, v| h2[k] == v }.merge(h2.dup.delete_if { |k, v| self.has_key?(k) })
+  end
+end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -46,10 +46,6 @@ def load_current_resource
     Chef::Application.fatal! "The name attribute for this resource is significant, and there cannot be whitespace. The preferred usage is to use the name of the artifact."
   end
 
-  chef_gem "activesupport" do
-    version "3.2.11"
-  end
-
   if Chef::Artifact.from_nexus?(@new_resource.artifact_location)
     chef_gem "nexus_cli" do
       version "4.0.2"
@@ -385,8 +381,6 @@ private
   # 
   # @return [Boolean]
   def has_manifest_changed?
-    require 'active_support/core_ext/hash'
-
     Chef::Log.debug "artifact_deploy[has_manifest_changed?] Loading manifest.yaml file from directory: #{release_path}"
     begin
       saved_manifest = YAML.load_file(::File.join(release_path, "manifest.yaml"))


### PR DESCRIPTION
We only ever use one method from activesupport, `Hash#diff`. Instead of installing the whole gem (and checking for it on each Chef run) we should just bring the method in on Hash and give credit.

Also of note is that this method is being deprecated in Activesupport, so eventually it would be gone anyway.
