### PR TITLE
S3 Files should be written in binary mode

### DIFF
--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -104,7 +104,7 @@ class Chef
           object = get_s3_object(bucket_name, object_name)
 
           Chef::Log.debug("Downloading #{object_name} from S3 bucket #{bucket_name}")
-          ::File.open(destination_file, 'w') do |file|
+          ::File.open(destination_file, 'wb') do |file|
             object.read do |chunk|
               file.write(chunk)
             end


### PR DESCRIPTION
Taken from #100 - http://stackoverflow.com/questions/12352230/using-aws-sdk-to-download-files-from-s3-encoding-not-right
