### PR TITLE
When Chef runs fail, the compiled resource will possibly display a password

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,9 +12,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :private_network, ip: "192.168.33.10"
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
-
   config.vm.provision :chef_solo do |chef|
     chef.json = {
       :artifact_test => {

--- a/libraries/chef_artifact_nexus_configuration.rb
+++ b/libraries/chef_artifact_nexus_configuration.rb
@@ -25,6 +25,11 @@ class Chef
         @url, @repository, @username, @password, @ssl_verify = url, repository, username, password, ssl_verify
       end
 
+      alias_method :inspect_without_masking, :inspect
+      def inspect
+        self.inspect_without_masking.sub(/@password=".*"/, '@password="MASKED"')
+      end
+
       def to_hash
         { 
           'url' => url,


### PR DESCRIPTION
In newer Chefs, a failure will show the compiled resource. My guess at the moment is that this will just require a change to `Chef::Artifact::NexusConfiguration#inspect`

```
nexus_configuration #<Chef::Artifact::NexusConfiguration:0x00000003c87870 @url="some erver", @repository="some repo", @username="some user", @password "some password", @ssl_verify=true>
```
