### PR TITLE
Remove version constraint from windows cookbook dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ supports "fedora"
 supports "ubuntu"
 supports "windows", ">= 6.0"
 
-depends "windows", "~> 1.8.0"
+depends "windows"


### PR DESCRIPTION
Without removing this constraint I can't use my existing recipes with the artifact cookbook - windows cookbook v1.11.0+ works with rubyzip gem v1.0.0+, which I'm already using. You cannot mix the latest windows cookbook with an older rubyzip gem and vice versa.
