### PR TITLE
Add aws-sdk gem to artifact_file load_current_resource

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -82,7 +82,7 @@ def load_current_resource
     end
 
     chef_gem "aws-sdk" do
-      version "1.11.0"
+      version "1.29.0"
     end
 
     @artifact_version = @new_resource.version

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -33,6 +33,10 @@ def load_current_resource
 
     @nexus_configuration = new_resource.nexus_configuration
     @nexus_connection = Chef::Artifact::Nexus.new(node, nexus_configuration)
+  elsif Chef::Artifact.from_s3?(@new_resource.location)
+    chef_gem "aws-sdk" do
+      version "1.29.0"
+    end
   end
   @file_location = new_resource.location
 


### PR DESCRIPTION
The artifact_file resource requires the aws-sdk gem, the same as the artifact_deploy resource, when the artifact location is from aws s3. Fixes the following:

```
LoadError
---------
cannot load such file -- aws-sdk

Cookbook Trace:
---------------
c:/chef/cache/cookbooks/artifact/libraries/chef_artifact.rb:92:in `retrieve_from_s3'
c:/chef/cache/cookbooks/artifact/providers/file.rb:48:in `block in class_from_file'
```

Note: I also bumped the aws-sdk gem version to the current latest (1.29.0).
