### PR TITLE
Fix #118 (sort of)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gem 'test-kitchen', git: 'git@github.com:opscode/test-kitchen.git'
 gem 'kitchen-vagrant', :group => :integration
 gem 'rspec'
 gem 'chef', '~> 10.18'
-gem 'aws-sdk', '= 1.15.0'
+gem 'aws-sdk', '~> 1.15'

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -200,6 +200,17 @@ class Chef
         version.casecmp("latest") == 0
       end
 
+      # Convenience metho for determining whether a version is a snapshot
+      # version.
+      #
+      # @param version [String] the version of the configured artifact to check
+      #
+      # @return [Boolean] true if the version ends with "-SNAPSHOT" (case
+      # sensitive)
+      def snapshot?(version)
+        version.end_with?("-SNAPSHOT")
+      end
+
       # Returns the currently deployed version of an artifact given that artifacts
       # installation directory by reading what directory the 'current' symlink
       # points to.

--- a/libraries/chef_artifact_nexus.rb
+++ b/libraries/chef_artifact_nexus.rb
@@ -28,7 +28,7 @@ class Chef
       # @return [String] the version number that latest resolves to or the passed in value
       def get_actual_version(coordinates)
         artifact = NexusCli::Artifact.new(coordinates)
-        if Chef::Artifact.latest?(artifact.version)
+        if Chef::Artifact.latest?(artifact.version) || Chef::Artifact.snapshot?(artifact.version)
           REXML::Document.new(remote.get_artifact_info(coordinates)).elements["//version"].text
         else
           artifact.version

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -206,8 +206,8 @@ describe Chef::Artifact do
   end
 
   describe ":snapshot?" do
-    specify { described_class.latest?('1.0.0-SNAPSHOT').should eq(true) }
-    specify { described_class.latest?('3.0.1').should eq(false) }
+    specify { described_class.snapshot?('1.0.0-SNAPSHOT').should eq(true) }
+    specify { described_class.snapshot?('3.0.1').should eq(false) }
   end
 
   describe ":get_s3_object" do

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -205,6 +205,11 @@ describe Chef::Artifact do
     specify { described_class.latest?('3.0.1').should eq(false) }
   end
 
+  describe ":snapshot?" do
+    specify { described_class.latest?('1.0.0-SNAPSHOT').should eq(true) }
+    specify { described_class.latest?('3.0.1').should eq(false) }
+  end
+
   describe ":get_s3_object" do
     require 'aws-sdk'
     AWS.stub!
@@ -276,7 +281,7 @@ describe Chef::Artifact do
         Chef::Config.stub(:[]).and_return({solo: true})
         Chef::DataBagItem.stub(:load).and_return(data_bag_item)
         described_class.should_receive(:get_s3_object).with("my-bucket", "my-file.tar.gz").and_return(mock_s3_object)
-        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
+        File.should_receive(:open).with("filename", "wb").and_yield(mock_output_file)
       end
 
       it "configures AWS correct and reads the file" do
@@ -299,7 +304,7 @@ describe Chef::Artifact do
         Chef::Config.stub(:[]).and_return({solo: true})
         Chef::DataBagItem.stub(:load).and_return(data_bag_item)
         described_class.should_receive(:get_s3_object).with("my-bucket", "my-file.tar.gz").and_return(mock_s3_object)
-        File.should_receive(:open).with("filename", "w").and_yield(mock_output_file)
+        File.should_receive(:open).with("filename", "wb").and_yield(mock_output_file)
       end
 
       it "configures AWS correct and reads the file" do


### PR DESCRIPTION
This pull should fix the artifact_deploy use case for SNAPSHOT versions. I'm
not entirely certain that it fixes artifact_package or artifact_file; in fact
I'm fairly certain that artifact_file still has some bugs around SNAPSHOTS.
However, this fixes _my_ use case, so that's good enough for me :smile:
