### PR TITLE
fix: load attr from lwrp name before require

### DIFF
--- a/resources/file.rb
+++ b/resources/file.rb
@@ -22,7 +22,7 @@
 actions :create
 default_action :create
 
-attribute :path, :kind_of => String, :required => true, :name_attribute => true
+attribute :path, :kind_of => String, :name_attribute => true, :required => true
 attribute :location, :kind_of => String
 attribute :checksum, :kind_of  => String
 attribute :owner, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]


### PR DESCRIPTION
PR #123 makes usage of path attribute instead of using directly LWRP name.
It caused regression when not specifying path option in recipes: Chef seems to check attribute before loading it up with name value.

Changing order between loading & check fixed this behaviour.

Sorry for not having detected this case so far.
