### PR TITLE
Allow artifact_file to handle snapshot and latest version correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
   resource. For example, when force is true, you can also change the value of owner and group to remap the deployed artifact to
   a new permissions scheme.
 
-##### Using artifact_file to download lastest artifact from Nexus 
+##### Using artifact_file to download lastest artifact from Nexus
 
     artifact_file "/tmp/my-artifact.jar" do
       location "com.test:my-artifact:tgz:LATEST"
@@ -457,7 +457,7 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
       action :create
     end
 
-  In this case, LWRP can't 'guess' artifact filename during runtime, so we don't know the final artifactname.
+  In this case, LWRP can't guess artifact filename during runtime, so we are not able to know the final artifactname.
   Adding a symlink to the file allow to always have a static file pointing to latest downloaded version.
 
 ##### Using artifact_file to download a file from an S3 bucket

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ location               | The location to the artifact file. Either a nexus ident
 checksum               | The SHA256 checksum for verifying URL downloads. Not used when location is Nexus     | String  |
 owner                  | Owner of the downloaded file                                                         | String  |
 group                  | Group of the downloaded file                                                         | String  |
+symlink                | If specified (absolute path), creates a symlink pointing to the downloaded artifact  | String  |
 after_download         | A proc containing resources to be executed only if the artifact has been downloaded  | Proc    |
 download_retries       | The number of times to attempt to download the file if it fails its integrity check  | Integer | 1
 
@@ -445,6 +446,19 @@ Your data_bag can contain both ```nexus``` and ```aws``` configuration.
   configuring the `force` attribute to a node attribute, will allow you to change some of the more finer grained aspects of the
   resource. For example, when force is true, you can also change the value of owner and group to remap the deployed artifact to
   a new permissions scheme.
+
+##### Using artifact_file to download lastest artifact from Nexus 
+
+    artifact_file "/tmp/my-artifact.jar" do
+      location "com.test:my-artifact:tgz:LATEST"
+      owner "me"
+      group "mes"
+      symlink "/tmp/my-artifact-LATEST.jar"
+      action :create
+    end
+
+  In this case, LWRP can't 'guess' artifact filename during runtime, so we don't know the final artifactname.
+  Adding a symlink to the file allow to always have a static file pointing to latest downloaded version.
 
 ##### Using artifact_file to download a file from an S3 bucket
 

--- a/libraries/chef_artifact_nexus.rb
+++ b/libraries/chef_artifact_nexus.rb
@@ -55,6 +55,16 @@ class Chef
       def get_artifact_sha(coordinates)
         REXML::Document.new(remote.get_artifact_info(coordinates)).elements["//sha1"].text
       end
+
+      # Makes a call to Nexus and parses the returned XML to return
+      # the Nexus Server's stored filename (with ext) for the given artifact.
+      #
+      # @param  coordinates [String] a colon-separated Maven identifier that represents the artifact
+      #
+      # @return [String] the filename for the artifact
+      def get_artifact_filename(coordinates)
+        ::File.basename(REXML::Document.new(remote.get_artifact_info(coordinates)).elements["//repositoryPath"].text)
+      end
     end
   end
 end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -206,6 +206,7 @@ private
   end
 
   # Manage a symlink pointing to artifact downloaded file
+  # Symlink attr should specify absolute symlink path
   #
   # @return [NilClass] the created path
   def create_symlink

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -209,7 +209,7 @@ private
   # Symlink attr should specify absolute symlink path
   #
   # @return [NilClass] the created path
-  def create_symlink()
+  def create_symlink
     link new_resource.symlink do
       to new_resource.path
       owner new_resource.owner

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -59,7 +59,7 @@ action :create do
       end
     elsif Chef::Artifact.from_nexus?(file_location)
     if Chef::Artifact.snapshot?(new_resource.location) || Chef::Artifact.latest?(new_resource.location)
-      Chef::Log.info "Snapshot version specifed, trying to replace destination filename from artifact metadatas"
+      Chef::Log.info "Snapshot version specifed - Trying to replace destination filename with artifact metadatas"
       new_resource.path(dst_filepath)
     end
       unless ::File.exists?(new_resource.path) && checksum_valid?

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -30,9 +30,11 @@ include Chef::Mixin::CreatePath
 def load_current_resource
   create_cache_path
   if Chef::Artifact.from_nexus?(new_resource.location)
+
     chef_gem "nexus_cli" do
       version "4.0.2"
     end
+
     @nexus_configuration = new_resource.nexus_configuration
     @nexus_connection = Chef::Artifact::Nexus.new(node, nexus_configuration)
   elsif Chef::Artifact.from_s3?(@new_resource.location)

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -59,7 +59,7 @@ action :create do
       end
     elsif Chef::Artifact.from_nexus?(file_location)
     if Chef::Artifact.snapshot?(new_resource.location) || Chef::Artifact.latest?(new_resource.location)
-      Chef::Log.info "Snapshot version specifed - Trying to replace destination filename with artifact metadatas"
+      Chef::Log.info "#{new_resource.name} is snapshot version - Filename is retrieved from metadata, provided name is ignored"
       new_resource.path(dst_filepath)
     end
       unless ::File.exists?(new_resource.path) && checksum_valid?

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -56,7 +56,7 @@ action :create do
         run_proc :after_download
       end
     elsif Chef::Artifact.from_nexus?(file_location)
-    if Chef::Artifact.snapshot?(new_resource.location) or Chef::Artifact.latest?(new_resource.location)
+    if Chef::Artifact.snapshot?(new_resource.location) || Chef::Artifact.latest?(new_resource.location)
       Chef::Log.info "Snapshot version specifed, trying to replace destination filename from artifact metadatas"
       new_resource.path(dst_filepath)
     end
@@ -183,7 +183,7 @@ private
 
   # Returns the full file destination path from resource dirname & metadata infos
   # This is only needed when provider is working with unpredictable filenames :
-  # *-SNAPSHOT & LATEST. Works for Nexus provider only. 
+  # *-SNAPSHOT & LATEST. Works for Nexus provider only.
   #
   # @return [String]
   def dst_filepath

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -39,7 +39,7 @@ def load_current_resource
     @nexus_connection = Chef::Artifact::Nexus.new(node, nexus_configuration)
 
     if Chef::Artifact.snapshot?(new_resource.location.split(':')[-1]) || Chef::Artifact.latest?(new_resource.location.split(':')[-1])
-      Chef::Log.info "#{new_resource.name} is snapshot version - filename is retrieved from metadata, existing name is ignored"
+      Chef::Log.info "#{new_resource.name} is a rolling/snapshot version - filename is retrieved from metadata, existing name is ignored"
       dest_filepath = ::File.join(
         ::File.dirname(new_resource.path),
         @nexus_connection.get_artifact_filename(new_resource.location)

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -55,14 +55,14 @@ action :create do
     if Chef::Artifact.from_s3?(file_location)
       unless ::File.exists?(new_resource.path) && checksum_valid?
         Chef::Artifact.retrieve_from_s3(node, file_location, new_resource.path)
-        create_symlink()
+        create_symlink() if new_resource.symlink
         run_proc :after_download
       end
     elsif Chef::Artifact.from_nexus?(file_location)
       unless ::File.exists?(new_resource.path) && checksum_valid?
         begin
           nexus_connection.retrieve_from_nexus(file_location, ::File.dirname(new_resource.path))
-          create_symlink()
+          create_symlink() if new_resource.symlink
           run_proc :after_download
         rescue NexusCli::PermissionsException => e
           msg = "The artifact server returned 401 (Unauthorized) when attempting to retrieve this artifact. Confirm that your credentials are correct."
@@ -71,7 +71,7 @@ action :create do
       end
     else
       remote_file_resource.run_action(:create)
-      create_symlink()
+      create_symlink() if new_resource.symlink
     end
     raise Chef::Artifact::ArtifactChecksumError unless checksum_valid?
     write_checksum if Chef::Artifact.from_nexus?(file_location) || Chef::Artifact.from_s3?(file_location)
@@ -209,11 +209,10 @@ private
   # Symlink attr should specify absolute symlink path
   #
   # @return [NilClass] the created path
-  def create_symlink
+  def create_symlink()
     link new_resource.symlink do
       to new_resource.path
       owner new_resource.owner
       group new_resource.group
-      only_if { new_resource.symlink }
     end
   end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -195,7 +195,7 @@ private
   # @return [NilClass]
   def snapshot_path
     if Chef::Artifact.from_nexus?(file_location)
-      if Chef::Artifact.snapshot?(file_location.split(':')[3]) || Chef::Artifact.latest?(file_location.split(':')[3])
+      if Chef::Artifact.snapshot?(file_location.split(':')[-1]) || Chef::Artifact.latest?(file_location.split(':')[-1])
         Chef::Log.info "#{new_resource.name} is snapshot version - Filename is retrieved from metadata, provided name is ignored"
         new_resource.path(dst_filepath)
       end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -35,6 +35,11 @@ def load_current_resource
       version "4.0.2"
     end
 
+    if Chef::Artifact.snapshot?(new_resource.location)
+      puts new_resource
+      new_resource.path(dst_filepath)
+    end
+
     @nexus_configuration = new_resource.nexus_configuration
     @nexus_connection = Chef::Artifact::Nexus.new(node, nexus_configuration)
   elsif Chef::Artifact.from_s3?(@new_resource.location)
@@ -177,4 +182,13 @@ private
   # @return [String]
   def read_checksum
     ::File.read(cached_checksum).strip
+  end
+
+  # Returns the full file destination path from resource dirname & metadata infos
+  # This is only needed when provider is working with unpredictable filenames :
+  # *-SNAPSHOT & LATEST. Provided filename is ignored then.
+  #
+  # @return [String]
+  def dst_filepath
+    ::File.join(::File.dirname(new_resource.name), nexus_connection.get_artifact_filename(file_location))
   end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -55,12 +55,14 @@ action :create do
     if Chef::Artifact.from_s3?(file_location)
       unless ::File.exists?(new_resource.path) && checksum_valid?
         Chef::Artifact.retrieve_from_s3(node, file_location, new_resource.path)
+        create_symlink()
         run_proc :after_download
       end
     elsif Chef::Artifact.from_nexus?(file_location)
       unless ::File.exists?(new_resource.path) && checksum_valid?
         begin
           nexus_connection.retrieve_from_nexus(file_location, ::File.dirname(new_resource.path))
+          create_symlink()
           run_proc :after_download
         rescue NexusCli::PermissionsException => e
           msg = "The artifact server returned 401 (Unauthorized) when attempting to retrieve this artifact. Confirm that your credentials are correct."
@@ -69,6 +71,7 @@ action :create do
       end
     else
       remote_file_resource.run_action(:create)
+      create_symlink()
     end
     raise Chef::Artifact::ArtifactChecksumError unless checksum_valid?
     write_checksum if Chef::Artifact.from_nexus?(file_location) || Chef::Artifact.from_s3?(file_location)
@@ -199,5 +202,17 @@ private
         Chef::Log.info "#{new_resource.name} is snapshot version - Filename is retrieved from metadata, provided name is ignored"
         new_resource.path(dst_filepath)
       end
+    end
+  end
+
+  # Manage a symlink pointing to artifact downloaded file
+  #
+  # @return [NilClass] the created path
+  def create_symlink
+    link new_resource.symlink do
+      to new_resource.path
+      owner new_resource.owner
+      group new_resource.group
+      only_if { new_resource.symlink }
     end
   end

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -22,7 +22,7 @@
 actions :create
 default_action :create
 
-attribute :path, :kind_of => String, :name_attribute => true, :required => true
+attribute :path, :kind_of => String, :required => true, :name_attribute => true
 attribute :location, :kind_of => String
 attribute :checksum, :kind_of  => String
 attribute :owner, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -27,6 +27,7 @@ attribute :location, :kind_of => String
 attribute :checksum, :kind_of  => String
 attribute :owner, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]
+attribute :symlink, :kind_of => String
 attribute :download_retries, :kind_of => Integer, :default => 1
 attribute :after_download, :kind_of => Proc
 attribute :nexus_configuration, :kind_of => Chef::Artifact::NexusConfiguration, :default => Chef::Artifact::NexusConfiguration.from_data_bag

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -22,7 +22,7 @@
 actions :create
 default_action :create
 
-attribute :path, :kind_of => String, :required => true, :name_attribute => true
+attribute :path, :kind_of => String, :name_attribute => true, :required => true
 attribute :location, :kind_of => String
 attribute :checksum, :kind_of  => String
 attribute :owner, :kind_of => String, :required => true, :regex => Chef::Config[:user_valid_regex]


### PR DESCRIPTION
issue #115

This patch allows `artifact_file` corectly downloading *-SNAPSHOT and LATEST version :
- It detects artifact version based on existing artifact class method (Thanks to @gregsymons)
- In case of "rolling version", it retrives artifact filename from Nexus metadata and merge it with provided destination folder.
- Cast a log info because provided filename is now ignored when asking for a snapshot version

Anyway, we are now able to download the artifact properly but we still do not know its name. I think it's still very interesting to correct the issue #112
