### PR TITLE
Add patch requirement for rehel boxes

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -69,7 +69,7 @@ def load_current_resource
       when 'debian'
         nokogiri_requirements = %W{gcc make libxml2 libxslt1.1 libxml2-dev libxslt1-dev}
       when 'rhel'
-        nokogiri_requirements = %W{gcc make libxml2 libxslt libxml2-devel libxslt-devel}
+        nokogiri_requirements = %W{gcc make libxml2 libxslt libxml2-devel libxslt-devel patch}
       else
         Chef::Log.warn "Watch out, you might not be able to install the nokogiri gem!"
       end


### PR DESCRIPTION
- discovered that whatever image i was using did not have the patch
  package installed by default causing this install to fail
- I didn't thoroughly test a debian install, but this hasn't been an issue until just recently.
