### PR TITLE
no owner/group right when copying on windows

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -241,8 +241,8 @@ def copy_artifact
   recipe_eval do
     execute "copy artifact" do
       command Chef::Artifact.copy_command_for(cached_tar_path, release_path)
-      user new_resource.owner
-      group new_resource.group
+      user new_resource.owner unless Chef::Artifact.windows?
+      group new_resource.group unless Chef::Artifact.windows?
     end
   end
 end


### PR DESCRIPTION
to fix a problem when copying files in Windows (and to be consistent with function `retrieve_from_local`). I'd like to add this fix : user/group are not set inside the `copy_artifact` method when copying in Windows. 
