### PR TITLE
Multi-period (tar.gz) file extensions fix for extract_artifact!

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -217,7 +217,7 @@ end
 # @return [void]
 def extract_artifact!
   recipe_eval do
-    case ::File.extname(cached_tar_path)
+    case extname(cached_tar_path)
     when /(tar|tgz|tar\.gz|tbz2|tbz|tar\.xz)$/
 
       taropts = [ '-x' ]
@@ -694,4 +694,25 @@ private
     manifest = generate_manifest(release_path)
     Chef::Log.debug "artifact_deploy[write_manifest] Writing manifest.yaml file to #{manifest_file}"
     ::File.open(manifest_file, "w") { |file| file.puts YAML.dump(manifest) }
+  end
+
+  # Returns the extension of a file. 
+  # Takes care of multiperiod extensions like tar.gz, tar.bz2, etc.
+  #
+  # @return [String] a String representing the extension. 
+  def extname(file)
+    basename = ::File.basename(file)
+    # in most cases, if count of '.'' <= 1 , consider as a "normal case" and
+    # return the native function result
+    return ::File.extname(file) if basename.count('.') <= 1
+    
+    # for other cases, we check against specific patterns
+    # here we specify some well-known multi-period extensions.
+    wellknown_extensions =  %w(tar.gz tar.bz2 tar.xz) 
+    wellknown_extensions.each do |extension|
+      return extension if basename.end_with? extension
+    end
+
+    # if it's none of the well-known extension, return the native function call
+    File.extname(file)
   end


### PR DESCRIPTION
Archives with multi-period extensions (like `tar.gz` for example) are not matched correctly by the `extract_artifact!` method.
The problem with the actual implementation is that `::File.extname()` for a multi-period filename extension doesn't extract all the part but only the last unique extension after the last `.`.  
For instance : `foo.tar.gz` gets an extension `.gz` instead of `.tar.gz`.

The use of an heuristic is necessary to _guess_ the real extension. This heuristic is done inside the new `extname()` function.

For this correction, this function will return : 

``` ruby
extname("test.rb")         #=> ".rb"
extname("a/b/d/test.rb")   #=> ".rb"
extname("foo.")            #=> ""
extname("test")            #=> ""
extname(".profile")        #=> ""
extname(".profile.sh")     #=> ".sh"
extname("myfile.tar.gz")   #=> ".tar.gz"
extname("my.file.tar.gz")  #=> ".tar.gz"
extname("tar.gz")          #=> ".gz"
```
