### PR TITLE
fix lack of after_download call for non-s3,non-nexus URLS

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -78,6 +78,7 @@ action :create do
       end
     else
       remote_file_resource.run_action(:create)
+      run_proc :after_download
     end
     raise Chef::Artifact::ArtifactChecksumError unless checksum_valid?
     write_checksum if Chef::Artifact.from_nexus?(file_location) || Chef::Artifact.from_s3?(file_location)


### PR DESCRIPTION
Couldn't figure out why my after_download proc wasn't working. Turns out it was only set to be called for s3 and nexus based remote sources..and not called for regular remote_file resources. :/

Simple one line addition.
