### PR TITLE
Configurable shared and releases folder names

### DIFF
--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -520,7 +520,7 @@ private
 
     exclude_filter = [get_current_release_version, 'current', new_resource.shared_name]
 
-    versions.reject! { |v| exclude_filter.include?(v.basename.to_s) }
+    versions.reject! { |v| exclude_filter.include?(v.basename.to_s) || v.file? }
 
     versions.sort_by(&:mtime)
   end

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -38,6 +38,8 @@ attr_reader :nexus_connection
 
 include Chef::Artifact::Helpers
 
+use_inline_resources
+
 def load_current_resource
   if Chef::Artifact.latest?(@new_resource.version) && Chef::Artifact.from_http?(@new_resource.artifact_location)
     Chef::Application.fatal! "You cannot specify the latest version for an artifact when attempting to download an artifact using http(s)!"

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -336,7 +336,7 @@ def delete_current_if_forcing!
       level :info
     end
 
-    directory ::File.join(new_resource.deploy_to, 'releases', artifact_version) do
+    directory ::File.join(new_resource.deploy_to, new_resource.releases_name, artifact_version) do
       recursive true
       action :delete
     end
@@ -370,7 +370,7 @@ def delete_previous_versions!
         action    :delete
       end
 
-      directory ::File.join(new_resource.deploy_to, 'releases', version.basename) do
+      directory ::File.join(new_resource.deploy_to, new_resource.releases_name, version.basename) do
         recursive true
         action    :delete
       end
@@ -503,7 +503,7 @@ private
   #
   # @return [String] the artifacts release path
   def get_release_path
-    ::File.join(new_resource.deploy_to, "releases", artifact_version)
+    ::File.join(new_resource.deploy_to, new_resource.releases_name, artifact_version)
   end
 
   # Searches the releases directory and returns an Array of version folders. After
@@ -512,11 +512,13 @@ private
   #
   # @return [Array] the mtime sorted array of currently installed versions
   def get_previous_version_paths
-    versions = Dir[::File.join(new_resource.deploy_to, "releases", '**')].collect do |v|
+    versions = Dir[::File.join(new_resource.deploy_to, new_resource.releases_name, '**')].collect do |v|
       Pathname.new(v)
     end
 
-    versions.reject! { |v| v.basename.to_s == get_current_release_version }
+    exclude_filter = [get_current_release_version, 'current', new_resource.shared_name]
+
+    versions.reject! { |v| exclude_filter.include?(v.basename.to_s) }
 
     versions.sort_by(&:mtime)
   end

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -27,6 +27,8 @@ attr_reader :nexus_connection
 include Chef::Artifact::Helpers
 include Chef::Mixin::CreatePath
 
+use_inline_resources
+
 def load_current_resource
   create_cache_path
   if Chef::Artifact.from_nexus?(new_resource.location)

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -78,6 +78,7 @@ action :create do
       end
     else
       remote_file_resource.run_action(:create)
+      run_proc :after_download if @remote_file_resource.updated_by_last_action?
     end
     raise Chef::Artifact::ArtifactChecksumError unless checksum_valid?
     write_checksum if Chef::Artifact.from_nexus?(file_location) || Chef::Artifact.from_s3?(file_location)

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+use_inline_resources
+
 attr_reader :nexus_configuration_object
 attr_reader :extension
 attr_reader :file_name

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -19,11 +19,11 @@
 # limitations under the License.
 #
 
-use_inline_resources
-
 attr_reader :nexus_configuration_object
 attr_reader :extension
 attr_reader :file_name
+
+use_inline_resources
 
 def load_current_resource
   if Chef::Artifact.from_nexus?(new_resource.location)

--- a/resources/deploy.rb
+++ b/resources/deploy.rb
@@ -29,6 +29,8 @@ attribute :artifact_name, :kind_of      => String, :required => true, :name_attr
 attribute :artifact_location, :kind_of  => String
 attribute :artifact_checksum, :kind_of  => String
 attribute :deploy_to, :kind_of          => String, :required => true
+attribute :shared_name, :kind_of        => String, :default => 'shared'
+attribute :releases_name, :kind_of      => String, :default => 'releases'
 attribute :download_retries, :kind_of   => Integer, :default => 1
 attribute :version, :kind_of            => String, :required => true
 attribute :owner, :kind_of              => String, :required => true, :regex => Chef::Config[:user_valid_regex]
@@ -72,5 +74,5 @@ def current_path
 end
 
 def shared_path
-  ::File.join(self.deploy_to, "shared")
+  ::File.join(self.deploy_to, self.shared_name)
 end


### PR DESCRIPTION
I am using for our artifacts deployment workflow, which is almost the same as provided by this wonderful cookbook.

However, we use 'common' folder in-place of 'shared' and we place release version-ed folders (like 1.2.3) to the root of deployment structure rather than to dedicated 'releases' folder.

This pull request provides ability to configure the names to be used for 'shared'  and 'releases' folder, still keeping the earlier used names as defaults, so that I can modify the resulting deployment layout  to match mine.

Changes are tested on cenots-6.6 and windows 2003 boxes
