### PR TITLE
Add single constant to set required nexus_cli version

### DIFF
--- a/libraries/chef_artifact_nexus.rb
+++ b/libraries/chef_artifact_nexus.rb
@@ -4,6 +4,8 @@ class Chef
   module Artifact
     class Nexus
 
+      NEXUS_CLI_VERSION = '4.0.2'.freeze
+
       attr_reader :node, :nexus_configuration
 
       def initialize(node, nexus_configuration)

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -50,7 +50,7 @@ def load_current_resource
 
   if Chef::Artifact.from_nexus?(@new_resource.artifact_location)
     chef_gem "nexus_cli" do
-      version "4.0.2"
+      version ::Chef::Artifact::Nexus::NEXUS_CLI_VERSION
     end
 
     @nexus_configuration_object = new_resource.nexus_configuration

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -32,7 +32,7 @@ def load_current_resource
   if Chef::Artifact.from_nexus?(new_resource.location)
 
     chef_gem "nexus_cli" do
-      version "4.0.2"
+      version ::Chef::Artifact::Nexus::NEXUS_CLI_VERSION
     end
 
     @nexus_configuration = new_resource.nexus_configuration

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -26,7 +26,7 @@ attr_reader :file_name
 def load_current_resource
   if Chef::Artifact.from_nexus?(new_resource.location)
     chef_gem "nexus_cli" do
-      version "4.0.2"
+      version ::Chef::Artifact::Nexus::NEXUS_CLI_VERSION
     end
     require 'nexus_cli'
     artifact = NexusCli::Artifact.new(new_resource.location)


### PR DESCRIPTION
It eases upgrade of nexus_cli gem and allows hack from wrapper cookbooks.

**Cc:** @aboten
